### PR TITLE
delay compaction

### DIFF
--- a/ingest/restore/restore.go
+++ b/ingest/restore/restore.go
@@ -191,7 +191,7 @@ func (rc *RestoreControlloer) restoreTables(ctx context.Context) error {
 
 func (rc *RestoreControlloer) compaction(ctx context.Context) error {
 	if !rc.cfg.KvIngest.Compact {
-		log.Warnf("Skip compaction !")
+		log.Warn("Skip compaction !")
 		return nil
 	}
 


### PR DESCRIPTION
So as to avoid useless deal of compaction during processing of kv data ingest in different batch with data overlap ,  here to delay the compaction request till all tables' restoring finishing. 