### PR TITLE
Continue if checksum mismatch

### DIFF
--- a/lightning/restore/restore.go
+++ b/lightning/restore/restore.go
@@ -245,6 +245,7 @@ func (rc *RestoreControlloer) checksum(ctx context.Context) error {
 		if remoteChecksum.Checksum != localChecksum.Sum() || remoteChecksum.TotalKVs != localChecksum.SumKVS() || remoteChecksum.TotalBytes != localChecksum.SumSize() {
 			log.Errorf("[%s] checksum mismatched remote vs local => (checksum: %d vs %d) (total_kvs: %d vs %d) (total_bytes:%d vs %d)",
 				table, remoteChecksum.Checksum, localChecksum.Sum(), remoteChecksum.TotalKVs, localChecksum.SumKVS(), remoteChecksum.TotalBytes, localChecksum.SumSize())
+			continue
 		}
 
 		log.Infof("[%s] checksum pass", table)


### PR DESCRIPTION
Otherwise, it logs "checksum pass" even if the checksum mismatches.