### PR TITLE
Import all data into TiKV before updating auto id

### DIFF
--- a/lightning/restore/restore.go
+++ b/lightning/restore/restore.go
@@ -640,6 +640,11 @@ func (tr *TableRestore) makeKVDeliver() (kv.KVDeliver, error) {
 }
 
 func (tr *TableRestore) onFinished() error {
+	// flush all kvs into TiKV
+	if err := tr.importKV(); err != nil {
+		return errors.Trace(err)
+	}
+
 	// generate meta kv
 	var (
 		tableMaxRowID int64
@@ -658,11 +663,6 @@ func (tr *TableRestore) onFinished() error {
 	tr.localChecksums[table] = checksum
 
 	if err := tr.restoreTableMeta(tableMaxRowID); err != nil {
-		return errors.Trace(err)
-	}
-
-	// flush all kvs into TiKV ~
-	if err := tr.importKV(); err != nil {
 		return errors.Trace(err)
 	}
 


### PR DESCRIPTION
We should not update table meta before all data has been imported.