### PR TITLE
Hide sql-mode in configuration template file

### DIFF
--- a/tidb-lightning.toml
+++ b/tidb-lightning.toml
@@ -35,8 +35,6 @@ user = "root"
 password = ""
 # PD Server of target cluster
 pd-addr = "127.0.0.1:2379"
-# Uncomment the following line if you want to set sql-mode. You can set it to empty string or any valid sql-mode value supported by tidb
-# sql-mode = ""
 # lightning uses some code of tidb(used as library), and the flag controls it's log level.
 log-level = "error"
 # set tidb session variable to speed up checksum/analyze table.


### PR DESCRIPTION
Exposing the sql-mode configuration to the users  is a little dangerous. We need to hide it but keep it in code. If it is necessary, we can tell them how to use sql-mode.

