### PR TITLE
restore: fix memory leak due to retained KvEncoder

### DIFF
--- a/lightning/restore/restore.go
+++ b/lightning/restore/restore.go
@@ -492,6 +492,7 @@ func newRegionRestoreTask(
 func (t *regionRestoreTask) Run(ctx context.Context) (err error) {
 	defer func() {
 		closeErr := t.encoder.Close()
+		t.encoder = nil
 		if closeErr != nil {
 			common.AppLogger.Errorf("restore region task err %v", errors.ErrorStack(closeErr))
 		}


### PR DESCRIPTION
When we import a table (as a `TableRestore` object) which spreads across multiple files, we will allocate N different `regionRestoreTask` objects, and each such object contains a `TableKVEncoder`. These task objects were not destroyed (only closed) until the entire table is processed. Hence, when a table is very large, these encoders will be persisted far beyond their useful lifetime. 

This PR fixes the leakage by immediately nullifying the encoder after it is closed. Experiment with a ~400 GB database shows that the heap usage now stays constant around 350–400 MB, instead of increasing linearly. 

@GregoryIan @holys PTAL.