### PR TITLE
Properly close the write stream, and extend the closeWithRetry() wait duration

### DIFF
--- a/lightning/kv/kv-deliver.go
+++ b/lightning/kv/kv-deliver.go
@@ -236,6 +236,7 @@ func (k *KVDeliverKeeper) RecycleClient(cli *KVDeliverClient) {
 		return
 	}
 
+	cli.exitTxn()
 	txnInfo.clients-- // ps : simple counter to mark txn is being followed
 	if txnInfo.clients <= 0 &&
 		txn.inStatus(txnPutting) &&

--- a/lightning/restore/restore.go
+++ b/lightning/restore/restore.go
@@ -689,7 +689,6 @@ func (t *regionRestoreTask) Run(ctx context.Context) (err error) {
 
 func (t *regionRestoreTask) run(ctx context.Context) (int64, uint64, *verify.KVChecksum, error) {
 	kvDeliver := t.delivers.AcquireClient(t.executor.tableMeta.DB, t.executor.tableMeta.Name)
-	// cause bug here.
 	defer t.delivers.RecycleClient(kvDeliver)
 
 	nextRowID, affectedRows, checksum, err := t.executor.Run(ctx, t.region, t.encoder, kvDeliver)


### PR DESCRIPTION
1. Before recycling a KVDeliverClient, do close the write stream immediately. Otherwise we need to wait for another acquisition which under the current architecture may never come

2. Increase the `closeWithRetry()` wait duration from 15 seconds to 30 seconds.