### PR TITLE
config: renamed -c to -config, keep -c as deprecated alias

### DIFF
--- a/docs/tidb-lightning-user-guide.md
+++ b/docs/tidb-lightning-user-guide.md
@@ -234,5 +234,5 @@ For details, see [Deploy TiDB Using Ansible](https://pingcap.com/docs/op-guide/a
 2. Run the executable file of `tidb-lightning`.
 
     ```
-    nohup ./tidb-lightning -c tidb-lightning.toml > nohup.out &
+    nohup ./tidb-lightning -config tidb-lightning.toml > nohup.out &
     ```

--- a/lightning/config/config.go
+++ b/lightning/config/config.go
@@ -113,7 +113,11 @@ func LoadConfig(args []string) (*Config, error) {
 	cfg.FlagSet = flag.NewFlagSet("lightning", flag.ContinueOnError)
 	fs := cfg.FlagSet
 
-	fs.StringVar(&cfg.ConfigFile, "c", "tidb-lightning.toml", "tidb-lightning configuration file")
+	// if both `-c` and `-config` are specified, the last one in the command line will take effect.
+	// the default value is assigned immediately after the StringVar() call,
+	// so it is fine to not give any default value for `-c`, to keep the `-h` page clean.
+	fs.StringVar(&cfg.ConfigFile, "c", "", "(deprecated alias of -config)")
+	fs.StringVar(&cfg.ConfigFile, "config", "tidb-lightning.toml", "tidb-lightning configuration file")
 	fs.BoolVar(&cfg.DoCompact, "compact", false, "do manual compaction on the target cluster, run then exit")
 	fs.StringVar(&cfg.SwitchMode, "switch-mode", "", "switch tikv into import mode or normal mode, values can be ['import', 'normal'], run then exit")
 	fs.BoolVar(&cfg.printVersion, "V", false, "print version of lightning")

--- a/tests/_utils/run_lightning
+++ b/tests/_utils/run_lightning
@@ -3,4 +3,4 @@
 set -eu
 TEST_DIR=/tmp/lightning_test_result
 
-bin/tidb-lightning.test -test.coverprofile="$TEST_DIR/cov.$TEST_NAME.${1-config}.out" DEVEL -c "tests/$TEST_NAME/${1-config}.toml"
+bin/tidb-lightning.test -test.coverprofile="$TEST_DIR/cov.$TEST_NAME.${1-config}.out" DEVEL -config "tests/$TEST_NAME/${1-config}.toml"


### PR DESCRIPTION
Fixes #68.

The usage page now looks like this:

```
Usage of lightning:
  -V	print version of lightning
  -c string
    	(deprecated alias of -config)
  -compact
    	do manual compaction on the target cluster, run then exit
  -config string
    	tidb-lightning configuration file (default "tidb-lightning.toml")
  -switch-mode string
    	switch tikv into import mode or normal mode, values can be ['import', 'normal'], run then exit
```