### PR TITLE
restore: do capture errors from the restore and analyze phases

### DIFF
--- a/tests/error_summary/run.sh
+++ b/tests/error_summary/run.sh
@@ -15,7 +15,10 @@ run_sql 'INSERT INTO error_summary.c VALUES (3, 9), (27, 81);'
 
 set +e
 run_lightning
+ERRORCODE=$?
 set -e
+
+[ "$ERRORCODE" -ne 0 ]
 
 # Verify that table `b` is indeed imported
 run_sql 'SELECT sum(id), sum(k) FROM error_summary.b'


### PR DESCRIPTION
Previously when these steps failed the errors will not be reflected from the error code and the process will just continue.

(Backport to 2.0 and 2.1 are recommended.)