### PR TITLE
restore: do record error comes from stream.Close()

### DIFF
--- a/lightning/restore/restore.go
+++ b/lightning/restore/restore.go
@@ -1117,7 +1117,11 @@ outside:
 		}
 		err = stream.Put(totalKVs)
 		if e := stream.Close(); e != nil {
-			common.AppLogger.Warnf("failed to close write stream: %s", e.Error())
+			if err != nil {
+				common.AppLogger.Warnf("failed to close write stream: %s", e.Error())
+			} else {
+				err = e
+			}
 		}
 		metrics.MarkTiming(deliverMark, start)
 		if err != nil {


### PR DESCRIPTION
Fix the symptom in TOOL-462. The underlying cause likely requires integrating the chunk checkpoints directly into tikv-importer. I'll explain more in TOOL-462.
