### PR TITLE
mydump: `ExportStatement` does not trim the last line

### DIFF
--- a/lightning/mydump/reader.go
+++ b/lightning/mydump/reader.go
@@ -79,14 +79,11 @@ func ExportStatement(sqlFile string, characterSet string) ([]byte, error) {
 	buffer := make([]byte, 0, f.Size()+1)
 	for {
 		line, err := br.ReadString('\n')
-		if errors.Cause(err) == io.EOF { // it will return EOF if there is no trailing new line.
-			if len(line) == 0 {
-				break
-			}
-		} else {
-			line = strings.TrimSpace(line[:len(line)-1])
+		if errors.Cause(err) == io.EOF && len(line) == 0 { // it will return EOF if there is no trailing new line.
+			break
 		}
 
+		line = strings.TrimSpace(line)
 		if len(line) == 0 {
 			continue
 		}

--- a/lightning/mydump/reader_test.go
+++ b/lightning/mydump/reader_test.go
@@ -32,6 +32,53 @@ func (s *testMydumpReaderSuite) TestExportStatementNoTrailingNewLine(c *C) {
 	c.Assert(data, DeepEquals, []byte("CREATE DATABASE whatever;"))
 }
 
+func (s *testMydumpReaderSuite) TestExportStatementWithComment(c *C) {
+	file, err := ioutil.TempFile("", "tidb_lightning_test_reader")
+	c.Assert(err, IsNil)
+	defer os.Remove(file.Name())
+
+	_, err = file.Write([]byte(`
+		/* whatever blabla 
+			multiple lines comment
+			multiple lines comment
+			multiple lines comment
+			multiple lines comment
+			multiple lines comment
+		 */;
+		CREATE DATABASE whatever;  
+`))
+	c.Assert(err, IsNil)
+	err = file.Close()
+	c.Assert(err, IsNil)
+
+	data, err := ExportStatement(file.Name(), "auto")
+	c.Assert(err, IsNil)
+	c.Assert(data, DeepEquals, []byte("CREATE DATABASE whatever;"))
+}
+
+func (s *testMydumpReaderSuite) TestExportStatementWithCommentNoTrailingNewLine(c *C) {
+	file, err := ioutil.TempFile("", "tidb_lightning_test_reader")
+	c.Assert(err, IsNil)
+	defer os.Remove(file.Name())
+
+	_, err = file.Write([]byte(`
+		/* whatever blabla 
+			multiple lines comment
+			multiple lines comment
+			multiple lines comment
+			multiple lines comment
+			multiple lines comment
+		 */;
+		CREATE DATABASE whatever;`))
+	c.Assert(err, IsNil)
+	err = file.Close()
+	c.Assert(err, IsNil)
+
+	data, err := ExportStatement(file.Name(), "auto")
+	c.Assert(err, IsNil)
+	c.Assert(data, DeepEquals, []byte("CREATE DATABASE whatever;"))
+}
+
 func (s *testMydumpReaderSuite) TestExportStatementGBK(c *C) {
 	file, err := ioutil.TempFile("", "tidb_lightning_test_reader")
 	c.Assert(err, IsNil)


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

`ExportStatement` does not trim the last line if there is no trailing new line.

### What is changed and how it works?

Trim the last line

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

Code changes

 - Has exported function/method change
 - Has exported variable/fields change
 - Has interface methods change
 - Has persistent data change

Side effects

Related changes
