### PR TITLE
[DNM] restore: limit the concurrency of post-process jobs

### DIFF
--- a/lightning/config/config.go
+++ b/lightning/config/config.go
@@ -69,10 +69,11 @@ func (c *Config) String() string {
 
 type Lightning struct {
 	common.LogConfig
-	TableConcurrency  int  `toml:"table-concurrency" json:"table-concurrency"`
-	RegionConcurrency int  `toml:"region-concurrency" json:"region-concurrency"`
-	ProfilePort       int  `toml:"pprof-port" json:"pprof-port"`
-	CheckRequirements bool `toml:"check-requirements" json:"check-requirements"`
+	TableConcurrency    int  `toml:"table-concurrency" json:"table-concurrency"`
+	RegionConcurrency   int  `toml:"region-concurrency" json:"region-concurrency"`
+	PostProcConcurrency int  `toml:"post-process-concurrency" json:"post-process-concurrency"`
+	ProfilePort         int  `toml:"pprof-port" json:"pprof-port"`
+	CheckRequirements   bool `toml:"check-requirements" json:"check-requirements"`
 }
 
 // PostRestore has some options which will be executed after kv restored.
@@ -127,9 +128,10 @@ func (d *Duration) MarshalJSON() ([]byte, error) {
 func NewConfig() *Config {
 	return &Config{
 		App: Lightning{
-			RegionConcurrency: runtime.NumCPU(),
-			TableConcurrency:  8,
-			CheckRequirements: true,
+			RegionConcurrency:   runtime.NumCPU(),
+			TableConcurrency:    8,
+			PostProcConcurrency: 8,
+			CheckRequirements:   true,
 		},
 		TiDB: DBStore{
 			SQLMode:                    "STRICT_TRANS_TABLES,NO_ENGINE_SUBSTITUTION",

--- a/lightning/worker/pool.go
+++ b/lightning/worker/pool.go
@@ -1,0 +1,35 @@
+package worker
+
+import (
+	"github.com/pingcap/tidb-lightning/lightning/metric"
+)
+
+type Pool struct {
+	limit   int
+	workers chan Worker
+	name    string
+}
+
+type Worker struct {
+	ID int
+}
+
+func NewPool(limit int, name string) *Pool {
+	workers := make(chan Worker, limit)
+	for i := 1; i <= limit; i++ {
+		workers <- Worker{ID: i}
+	}
+
+	metric.IdleWorkersGauge.WithLabelValues(name).Set(float64(limit))
+	return &Pool{limit, workers, name}
+}
+
+func (pool *Pool) Apply() Worker {
+	worker := <-pool.workers
+	metric.IdleWorkersGauge.WithLabelValues(pool.name).Set(float64(len(pool.workers)))
+	return worker
+}
+func (pool *Pool) Recycle(worker Worker) {
+	pool.workers <- worker
+	metric.IdleWorkersGauge.WithLabelValues(pool.name).Set(float64(len(pool.workers)))
+}

--- a/tidb-lightning.toml
+++ b/tidb-lightning.toml
@@ -14,6 +14,10 @@ table-concurrency = 8
 # region-concurrency default to runtime.NumCPU()
 # region-concurrency =
 
+# post-process-concurrency controls the maximum simultaneous post-process jobs (import, compact, checksum and analyze)
+# can be done in parallel. This is to prevent adding too much stress on the cluster.
+post-process-concurrency = 8
+
 # logging
 level = "info"
 file = "tidb-lightning.log"


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

> DNM: Just for the 10T test for now.

### What problem does this PR solve? <!--add issue link with summary if exists-->

If we simultaneously run many post-processing tasks (import, compact, checksum, analyze), it may stress the cluster too much making them unresponsive.

### What is changed and how it works?

Add a worker pool around the post-processing jobs to limit the concurrency.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has exported function/method change
 - Has exported variable/fields change
 - Has interface methods change
 - Has persistent data change

Side effects

 - Possible performance regression

Related changes

 - Need to update the documentation
 - Need to update the `tidb-ansible` repository
 - Need to be included in the release note