### PR TITLE
mydump,restore: Make 1 Chunk = 1 File and Use Coarse Row ID Assignment

### DIFF
--- a/lightning/mydump/region_test.go
+++ b/lightning/mydump/region_test.go
@@ -36,10 +36,9 @@ func (s *testMydumpRegionSuite) TestTableRegion(c *C) {
 	cfg := &config.Config{Mydumper: config.MydumperRuntime{SourceDir: "./examples"}}
 	loader, _ := NewMyDumpLoader(cfg)
 	dbMeta := loader.GetDatabases()[0]
-	founder := NewRegionFounder(defMinRegionSize)
 
 	for _, meta := range dbMeta.Tables {
-		regions, err := founder.MakeTableRegions(meta)
+		regions, err := MakeTableRegions(meta, 1)
 		c.Assert(err, IsNil)
 
 		table := meta.Name
@@ -61,19 +60,18 @@ func (s *testMydumpRegionSuite) TestTableRegion(c *C) {
 			c.Assert(err, IsNil)
 			tolFileSize += fileSize
 		}
-		// var tolRegionSize int64 = 0
-		// for _, region := range regions {
-		// 	tolRegionSize += region.Size()
-		// }
-		// c.Assert(tolRegionSize, Equals, tolFileSize)
-		// (The size will not be equal since the comments at the end are omitted)
-
-		// check - rows num
-		var tolRows int64 = 0
+		var tolRegionSize int64 = 0
 		for _, region := range regions {
-			tolRows += region.Rows()
+			tolRegionSize += region.Size()
 		}
-		c.Assert(tolRows, Equals, expectedTuplesCount[table])
+		c.Assert(tolRegionSize, Equals, tolFileSize)
+
+		// // check - rows num
+		// var tolRows int64 = 0
+		// for _, region := range regions {
+		// 	tolRows += region.Rows()
+		// }
+		// c.Assert(tolRows, Equals, expectedTuplesCount[table])
 
 		// check - range
 		regionNum := len(regions)
@@ -98,10 +96,9 @@ func (s *testMydumpRegionSuite) TestRegionReader(c *C) {
 	cfg := &config.Config{Mydumper: config.MydumperRuntime{SourceDir: "./examples"}}
 	loader, _ := NewMyDumpLoader(cfg)
 	dbMeta := loader.GetDatabases()[0]
-	founder := NewRegionFounder(defMinRegionSize)
 
 	for _, meta := range dbMeta.Tables {
-		regions, err := founder.MakeTableRegions(meta)
+		regions, err := MakeTableRegions(meta, 1)
 		c.Assert(err, IsNil)
 
 		tolValTuples := 0

--- a/tests/checkpoint_chunks/run.sh
+++ b/tests/checkpoint_chunks/run.sh
@@ -43,8 +43,6 @@ check_contains "count(i): $(($ROW_COUNT*$CHUNK_COUNT))"
 check_contains "sum(i): $(( $ROW_COUNT*$CHUNK_COUNT*(($CHUNK_COUNT+2)*$ROW_COUNT + 1)/2 ))"
 run_sql "SELECT count(*) FROM tidb_lightning_checkpoint_test_cpch.table_v1 WHERE status >= 200"
 check_contains "count(*): 1"
-run_sql "SELECT count(*) FROM tidb_lightning_checkpoint_test_cpch.chunk_v3 WHERE pos = end_offset"
-check_contains "count(*): $CHUNK_COUNT"
 
 # Repeat, but using the file checkpoint
 run_sql 'DROP DATABASE IF EXISTS cpch_tsr'

--- a/tests/examples/run.sh
+++ b/tests/examples/run.sh
@@ -46,9 +46,9 @@ check_contains 'sum(crc32(name)): 21388950023608'
 
 # Ensure the AUTO_INCREMENT value is properly defined
 run_sql "insert into mocker_test.tbl_autoid (name) values ('new');"
-run_sql "select id from mocker_test.tbl_autoid where name = 'new';"
+run_sql "select id > 10000 from mocker_test.tbl_autoid where name = 'new';"
 check_not_contains '* 2. row *'
-check_contains 'id: 10001'
+check_contains 'id > 10000: 1'
 
 run_sql 'select count(*), avg(age), max(name), min(name), sum(crc32(name)) from mocker_test.tbl_multi_index;'
 check_contains 'count(*): 10000'


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Implement [RFC 2](https://docs.google.com/document/d/1cFAX9KMmqzgCxIC-E_jNHB7wxCs-ab6oM-2NlAb7b8w/edit?usp=sharing), reduces the 300G import time (which has a *slow disk*) from ~3¼ hours to ~2⅗ hours, improving the speed by about 18%.

### What is changed and how it works?

As explained in the RFC,

1. Now a chunk is always as large as the whole file
2. Row IDs are no longer assigned consecutively, the IDs between two chunks will be separated by the theoretical maximum.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
    * Try to import 10G and 300G of data and verify the time taken is shorter than 6 minutes / 3 hours respectively.

Code changes

 - (We need to rewrite this section)

Side effects

 - Possible performance regression

Related changes

 - Need to update the documentation
 - Need to update the `tidb-ansible` repository
 - Need to be included in the release note