### PR TITLE
Limit closed engine count for coordinating `write` and `import`

### DIFF
--- a/lightning/config/config.go
+++ b/lightning/config/config.go
@@ -91,9 +91,10 @@ type Lightning struct {
 
 // PostRestore has some options which will be executed after kv restored.
 type PostRestore struct {
-	Compact  bool `toml:"compact" json:"compact"`
-	Checksum bool `toml:"checksum" json:"checksum"`
-	Analyze  bool `toml:"analyze" json:"analyze"`
+	Level1Compact *bool `toml:"level-1-compact" json:"level-1-compact"`
+	Compact       bool  `toml:"compact" json:"compact"`
+	Checksum      bool  `toml:"checksum" json:"checksum"`
+	Analyze       bool  `toml:"analyze" json:"analyze"`
 }
 
 type MydumperRuntime struct {
@@ -226,6 +227,12 @@ func (cfg *Config) Load() error {
 		case "file":
 			cfg.Checkpoint.DSN = "/tmp/" + cfg.Checkpoint.Schema + ".pb"
 		}
+	}
+
+	// If the level 1 compact configuration not found, default to true
+	if cfg.PostRestore.Level1Compact == nil {
+		cfg.PostRestore.Level1Compact = new(bool)
+		*cfg.PostRestore.Level1Compact = true
 	}
 
 	return nil

--- a/lightning/restore/restore.go
+++ b/lightning/restore/restore.go
@@ -566,8 +566,9 @@ func (t *TableRestore) restoreEngine(
 	cp *EngineCheckpoint,
 ) (*kv.ClosedEngine, *worker.Worker, error) {
 	if cp.Status >= CheckpointStatusClosed {
+		w := rc.closedEngineLimit.Apply()
 		closedEngine, err := rc.importer.UnsafeCloseEngine(ctx, t.tableName, engineID)
-		return closedEngine, nil, errors.Trace(err)
+		return closedEngine, w, errors.Trace(err)
 	}
 
 	timer := time.Now()

--- a/lightning/worker/worker.go
+++ b/lightning/worker/worker.go
@@ -52,14 +52,10 @@ func (pool *Pool) Apply() *Worker {
 	return worker
 }
 
-<<<<<<< HEAD
 func (pool *Pool) Recycle(worker *Worker) {
-=======
-func (pool *RestoreWorkerPool) Recycle(worker *RestoreWorker) {
 	if worker == nil {
 		panic("invalid restore worker")
 	}
->>>>>>> worker: panic if recycle a nil worker
 	pool.workers <- worker
 	metric.IdleWorkersGauge.WithLabelValues(pool.name).Set(float64(len(pool.workers)))
 }

--- a/lightning/worker/worker.go
+++ b/lightning/worker/worker.go
@@ -52,7 +52,14 @@ func (pool *Pool) Apply() *Worker {
 	return worker
 }
 
+<<<<<<< HEAD
 func (pool *Pool) Recycle(worker *Worker) {
+=======
+func (pool *RestoreWorkerPool) Recycle(worker *RestoreWorker) {
+	if worker == nil {
+		panic("invalid restore worker")
+	}
+>>>>>>> worker: panic if recycle a nil worker
 	pool.workers <- worker
 	metric.IdleWorkersGauge.WithLabelValues(pool.name).Set(float64(len(pool.workers)))
 }

--- a/tidb-lightning.toml
+++ b/tidb-lightning.toml
@@ -104,7 +104,9 @@ checksum-table-concurrency = 16
 [post-restore]
 # if set true, checksum will do ADMIN CHECKSUM TABLE <table> for each table.
 checksum = true
-# if set true, compact will do compaction to tikv data.
+# if set to true, compact will do level 1 compaction to tikv data.
+level-1-compact = true
+# if set true, compact will do full compaction to tikv data.
 compact = true
 # if set true, analyze will do ANALYZE TABLE <table> for each table.
 analyze = true

--- a/tidb-lightning.toml
+++ b/tidb-lightning.toml
@@ -105,6 +105,7 @@ checksum-table-concurrency = 16
 # if set true, checksum will do ADMIN CHECKSUM TABLE <table> for each table.
 checksum = true
 # if set to true, compact will do level 1 compaction to tikv data.
+# if this setting is missing, the default value is also true.
 level-1-compact = true
 # if set true, compact will do full compaction to tikv data.
 compact = true

--- a/tidb-lightning.toml
+++ b/tidb-lightning.toml
@@ -106,7 +106,7 @@ checksum-table-concurrency = 16
 checksum = true
 # if set to true, compact will do level 1 compaction to tikv data.
 # if this setting is missing, the default value is also true.
-level-1-compact = true
+level-1-compact = false
 # if set true, compact will do full compaction to tikv data.
 compact = true
 # if set true, analyze will do ANALYZE TABLE <table> for each table.


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Limit closed engine count for coordinating `write` and `import`

### What is changed and how it works?

Apply a worker before call `engine.Close()` and release worker after `engine.Cleanup`

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)

Code changes

Side effects

Related changes
