### PR TITLE
Rename exported types in package `lightning/worker`

### DIFF
--- a/lightning/mydump/parser.go
+++ b/lightning/mydump/parser.go
@@ -34,7 +34,7 @@ type ChunkParser struct {
 	// cache
 	remainBuf *bytes.Buffer
 	appendBuf *bytes.Buffer
-	ioWorkers *worker.RestoreWorkerPool
+	ioWorkers *worker.Pool
 }
 
 // Chunk represents a portion of the data file.
@@ -52,7 +52,7 @@ type Row struct {
 }
 
 // NewChunkParser creates a new parser which can read chunks out of a file.
-func NewChunkParser(reader io.Reader, blockBufSize int64, ioWorkers *worker.RestoreWorkerPool) *ChunkParser {
+func NewChunkParser(reader io.Reader, blockBufSize int64, ioWorkers *worker.Pool) *ChunkParser {
 	return &ChunkParser{
 		reader:    reader,
 		blockBuf:  make([]byte, blockBufSize*config.BufferSizeScale),

--- a/lightning/mydump/parser_test.go
+++ b/lightning/mydump/parser_test.go
@@ -28,7 +28,7 @@ func (s *testMydumpParserSuite) TestReadRow(c *C) {
 			"insert another_table values (10, 11, 12, '(13)', '(', 14, ')');",
 	)
 
-	ioWorkers := worker.NewRestoreWorkerPool(context.Background(), 5, "test")
+	ioWorkers := worker.NewPool(context.Background(), 5, "test")
 	parser := mydump.NewChunkParser(reader, config.ReadBlockSize, ioWorkers)
 
 	c.Assert(parser.ReadRow(), IsNil)
@@ -77,7 +77,7 @@ func (s *testMydumpParserSuite) TestReadChunks(c *C) {
 		INSERT foo VALUES (29,30,31,32),(33,34,35,36);
 	`)
 
-	ioWorkers := worker.NewRestoreWorkerPool(context.Background(), 5, "test")
+	ioWorkers := worker.NewPool(context.Background(), 5, "test")
 	parser := mydump.NewChunkParser(reader, config.ReadBlockSize, ioWorkers)
 
 	chunks, err := parser.ReadChunks(32)
@@ -124,7 +124,7 @@ func (s *testMydumpParserSuite) TestNestedRow(c *C) {
 		("789",CONVERT("[]" USING UTF8MB4));
 	`)
 
-	ioWorkers := worker.NewRestoreWorkerPool(context.Background(), 5, "test")
+	ioWorkers := worker.NewPool(context.Background(), 5, "test")
 	parser := mydump.NewChunkParser(reader, config.ReadBlockSize, ioWorkers)
 	chunks, err := parser.ReadChunks(96)
 

--- a/lightning/worker/worker_test.go
+++ b/lightning/worker/worker_test.go
@@ -20,7 +20,7 @@ func TestNewRestoreWorkerPool(t *testing.T) {
 }
 
 func (s *testWorkerPool) TestApplyRecycle(c *C) {
-	pool := worker.NewRestoreWorkerPool(context.Background(), 3, "test")
+	pool := worker.NewPool(context.Background(), 3, "test")
 
 	w1, w2, w3 := pool.Apply(), pool.Apply(), pool.Apply()
 	c.Assert(w1.ID, Equals, int64(1))


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-Lightning! Please read the [CONTRIBUTING](https://github.com/pingcap/tidb-lightning/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Rename `worker.RestoreWorker` to `worker.Worker` and `worker.RestoreWorkerPool`
to `worker.Pool`, make it more in line with the Golang naming style.

### What is changed and how it works?

Rename exported types and related references.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

Side effects

Related changes
