### PR TITLE
tidb-lightning-ctl: added --import-engine and --cleanup-engine commands

### DIFF
--- a/cmd/tidb-lightning-ctl/main.go
+++ b/cmd/tidb-lightning-ctl/main.go
@@ -19,12 +19,15 @@ import (
 	"fmt"
 	"os"
 	"path"
+	"strconv"
+	"strings"
 
 	"github.com/pingcap/errors"
 	"github.com/pingcap/kvproto/pkg/import_sstpb"
 	"github.com/pingcap/tidb-lightning/lightning/config"
 	"github.com/pingcap/tidb-lightning/lightning/kv"
 	"github.com/pingcap/tidb-lightning/lightning/restore"
+	"github.com/satori/go.uuid"
 )
 
 func main() {
@@ -43,6 +46,9 @@ func run() error {
 
 	compact := fs.Bool("compact", false, "do manual compaction on the target cluster")
 	mode := fs.String("switch-mode", "", "switch tikv into import mode or normal mode, values can be ['import', 'normal']")
+
+	flagImportEngine := fs.String("import-engine", "", "manually import a closed engine (value can be '`db`.`table`:123' or a UUID")
+	flagCleanupEngine := fs.String("cleanup-engine", "", "manually delete a closed engine")
 
 	cpRemove := fs.String("checkpoint-remove", "", "remove the checkpoint associated with the given table (value can be 'all' or '`db`.`table`')")
 	cpErrIgnore := fs.String("checkpoint-error-ignore", "", "ignore errors encoutered previously on the given table (value can be 'all' or '`db`.`table`'); may corrupt this table if used incorrectly")
@@ -65,6 +71,13 @@ func run() error {
 	if len(*mode) != 0 {
 		return errors.Trace(switchMode(ctx, cfg, *mode))
 	}
+	if len(*flagImportEngine) != 0 {
+		return errors.Trace(importEngine(ctx, cfg, *flagImportEngine))
+	}
+	if len(*flagCleanupEngine) != 0 {
+		return errors.Trace(cleanupEngine(ctx, cfg, *flagCleanupEngine))
+	}
+
 	if len(*cpRemove) != 0 {
 		return errors.Trace(checkpointRemove(ctx, cfg, *cpRemove))
 	}
@@ -232,4 +245,52 @@ func checkpointDump(ctx context.Context, cfg *config.Config, dumpFolder string) 
 		return errors.Trace(err)
 	}
 	return nil
+}
+
+func unsafeCloseEngine(ctx context.Context, importer *kv.Importer, engine string) (*kv.ClosedEngine, error) {
+	if index := strings.LastIndexByte(engine, ':'); index >= 0 {
+		tableName := engine[:index]
+		engineID, err := strconv.Atoi(engine[index+1:])
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		ce, err := importer.UnsafeCloseEngine(ctx, tableName, engineID)
+		return ce, errors.Trace(err)
+	}
+
+	engineUUID, err := uuid.FromString(engine)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	ce, err := importer.UnsafeCloseEngineWithUUID(ctx, "<tidb-lightning-ctl>", engineUUID)
+	return ce, errors.Trace(err)
+}
+
+func importEngine(ctx context.Context, cfg *config.Config, engine string) error {
+	importer, err := kv.NewImporter(ctx, cfg.TikvImporter.Addr, cfg.TiDB.PdAddr)
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	ce, err := unsafeCloseEngine(ctx, importer, engine)
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	return errors.Trace(ce.Import(ctx))
+}
+
+func cleanupEngine(ctx context.Context, cfg *config.Config, engine string) error {
+	importer, err := kv.NewImporter(ctx, cfg.TikvImporter.Addr, cfg.TiDB.PdAddr)
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	ce, err := unsafeCloseEngine(ctx, importer, engine)
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	return errors.Trace(ce.Cleanup(ctx))
 }

--- a/lightning/kv/importer.go
+++ b/lightning/kv/importer.go
@@ -298,7 +298,7 @@ type ClosedEngine struct {
 func (engine *OpenedEngine) Close(ctx context.Context) (*ClosedEngine, error) {
 	common.AppLogger.Infof("[%s] [%s] engine close", engine.tag, engine.uuid)
 	timer := time.Now()
-	closedEngine, err := engine.importer.unsafeCloseEngine(ctx, engine.tag, engine.uuid)
+	closedEngine, err := engine.importer.UnsafeCloseEngineWithUUID(ctx, engine.tag, engine.uuid)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -315,10 +315,11 @@ func (engine *OpenedEngine) Close(ctx context.Context) (*ClosedEngine, error) {
 func (importer *Importer) UnsafeCloseEngine(ctx context.Context, tableName string, engineID int) (*ClosedEngine, error) {
 	tag := makeTag(tableName, engineID)
 	engineUUID := uuid.NewV5(engineNamespace, tag)
-	return importer.unsafeCloseEngine(ctx, tag, engineUUID)
+	return importer.UnsafeCloseEngineWithUUID(ctx, tag, engineUUID)
 }
 
-func (importer *Importer) unsafeCloseEngine(ctx context.Context, tag string, engineUUID uuid.UUID) (*ClosedEngine, error) {
+// UnsafeCloseEngineWithUUID closes the engine using the UUID alone.
+func (importer *Importer) UnsafeCloseEngineWithUUID(ctx context.Context, tag string, engineUUID uuid.UUID) (*ClosedEngine, error) {
 	req := &kv.CloseEngineRequest{
 		Uuid: engineUUID.Bytes(),
 	}


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-Lightning! Please read the [CONTRIBUTING](https://github.com/pingcap/tidb-lightning/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

This is mainly intended for speeding up debugging tikv-importer's import step by entirely skipping the "write" step.

### What is changed and how it works?

Expose tikv-importer's `ImportEngine` and `CleanupEngine` APIs to `tidb-lightning-ctl`.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)
    * 

Side effects

Related changes

 - Need to update the documentation
