### PR TITLE
*: parameter type fix

### DIFF
--- a/cmd/tidb-lightning-ctl/main.go
+++ b/cmd/tidb-lightning-ctl/main.go
@@ -254,7 +254,7 @@ func unsafeCloseEngine(ctx context.Context, importer *kv.Importer, engine string
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
-		ce, err := importer.UnsafeCloseEngine(ctx, tableName, engineID)
+		ce, err := importer.UnsafeCloseEngine(ctx, tableName, int32(engineID))
 		return ce, errors.Trace(err)
 	}
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-Lightning! Please read the [CONTRIBUTING](https://github.com/pingcap/tidb-lightning/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
fix error
```bash
cmd/tidb-lightning-ctl/main.go:257:40: cannot use engineID (type int) as type int32 in argument to importer.UnsafeCloseEngine
```

### What is changed and how it works?
add type cast

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test