### PR TITLE
test: fix cleanup script to enable re-run integration test locally

### DIFF
--- a/tests/run.sh
+++ b/tests/run.sh
@@ -23,7 +23,7 @@ stop_services() {
     killall -9 tidb-server || true
     killall -9 tikv-importer || true
 
-    find "$TEST_DIR" -d -mindepth 1 -not -name 'cov.*' -not \( -depth 1 -name '*.log' \) -delete || true
+    find "$TEST_DIR" -maxdepth 1 -not -path "$TEST_DIR" -not -name "cov.*" -not -name "*.log" | xargs rm -r || true
 }
 
 start_services() {


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-Lightning! Please read the [CONTRIBUTING](https://github.com/pingcap/tidb-lightning/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

currently cleanup script in integration test does not work, if developer wants to re-run integration test in his/her local environment, he/she has to clean /tmp/lightning_test_result manually

### What is changed and how it works?

fix cleanup scripts

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Integration test
 - Manual test (add detailed scripts or steps below)
     - run integration test in local environment multiple times