### PR TITLE
checkpoint: fix checkpoint not updated in some scenario

### DIFF
--- a/lightning/common/util.go
+++ b/lightning/common/util.go
@@ -39,10 +39,6 @@ const (
 	defaultMaxRetry = 3
 )
 
-func Percent(a int, b int) string {
-	return fmt.Sprintf("%.2f %%", float64(a)/float64(b)*100)
-}
-
 func ToDSN(host string, port int, user string, psw string) string {
 	return fmt.Sprintf("%s:%s@tcp(%s:%d)/?charset=utf8", user, psw, host, port)
 }

--- a/lightning/mydump/csv_parser.go
+++ b/lightning/mydump/csv_parser.go
@@ -109,7 +109,6 @@ func (parser *CSVParser) ReadRow() error {
 		tok, content, err := parser.lex()
 		switch errors.Cause(err) {
 		case nil:
-			break
 		case io.EOF:
 			if hasField {
 				tok = csvTokNewLine


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-Lightning! Please read the [CONTRIBUTING](https://github.com/pingcap/tidb-lightning/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Test `checkpoint_error_destroy` in integration got error randomly, both in local environment and JenkinsCI.
Lightning could exit before all checkpoints are saved, as the `WaitGroup` is not always 
added before this line https://github.com/pingcap/tidb-lightning/blob/master/lightning/restore/restore.go#L204 returns

### What is changed and how it works?

1. After `RestoreController.Run` is returned, no more messages will be sent to `rc.saveCpCh`, so we can close it safely and ensure all `saveCp` are consumed
2. remove some unused code

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Integration test