### PR TITLE
restore: add local checksum log

### DIFF
--- a/lightning/restore/restore.go
+++ b/lightning/restore/restore.go
@@ -830,7 +830,7 @@ func (t *TableRestore) postProcess(ctx context.Context, rc *RestoreController, c
 			localChecksum.Add(&chunk.Checksum)
 		}
 	}
-	common.AppLogger.Errorf("[%s] local checksum [sum:%d, kvs:%d, size:%v]",
+	common.AppLogger.Infof("[%s] local checksum [sum:%d, kvs:%d, size:%v]",
 		t.tableName, localChecksum.Sum(), localChecksum.SumKVS(), localChecksum.SumSize())
 	if cp.Status < CheckpointStatusChecksummed {
 		if !rc.cfg.PostRestore.Checksum {


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-Lightning! Please read the [CONTRIBUTING](https://github.com/pingcap/tidb-lightning/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Add local checksum information, which helps us to compare checksum manually when executing `ADMIN CHECKSUM TABLE table_name` timeout.

### What is changed and how it works?

Add some logs.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Integration test

Side effects

N/A

Related changes

N/A