### PR TITLE
restore: give priority to small tables for importing

### DIFF
--- a/lightning/metric/metric.go
+++ b/lightning/metric/metric.go
@@ -141,6 +141,14 @@ var (
 			Buckets:   prometheus.ExponentialBuckets(0.001, 3.1622776601683795, 10),
 		},
 	)
+	RowKVDeliverSecondsHistogram = prometheus.NewHistogram(
+		prometheus.HistogramOpts{
+			Namespace: "lightning",
+			Name:      "row_kv_deliver_seconds",
+			Help:      "time needed to deliver kvs of a single row",
+			Buckets:   prometheus.ExponentialBuckets(0.001, 3.1622776601683795, 10),
+		},
+	)
 	BlockDeliverSecondsHistogram = prometheus.NewHistogram(
 		prometheus.HistogramOpts{
 			Namespace: "lightning",
@@ -186,6 +194,7 @@ func init() {
 	prometheus.MustRegister(RowReadSecondsHistogram)
 	prometheus.MustRegister(RowReadBytesHistogram)
 	prometheus.MustRegister(RowEncodeSecondsHistogram)
+	prometheus.MustRegister(RowKVDeliverSecondsHistogram)
 	prometheus.MustRegister(BlockDeliverSecondsHistogram)
 	prometheus.MustRegister(BlockDeliverBytesHistogram)
 	prometheus.MustRegister(BlockDeliverKVPairsHistogram)

--- a/lightning/mydump/loader.go
+++ b/lightning/mydump/loader.go
@@ -44,6 +44,7 @@ type MDTableMeta struct {
 	SchemaFile string
 	DataFiles  []string
 	charSet    string
+	TotalSize  int64
 }
 
 func (m *MDTableMeta) GetSchema() string {
@@ -121,6 +122,7 @@ func (ftype fileType) String() string {
 type fileInfo struct {
 	tableName filter.Table
 	path      string
+	size      int64
 }
 
 var tableNameRegexp = regexp.MustCompile(`^([^.]+)\.(.*?)(?:\.[0-9]+)?$`)
@@ -184,6 +186,7 @@ func (s *mdLoaderSetup) setup(dir string) error {
 			}
 		}
 		tableMeta.DataFiles = append(tableMeta.DataFiles, fileInfo.path)
+		tableMeta.TotalSize += fileInfo.size
 	}
 
 	return nil
@@ -205,7 +208,7 @@ func (s *mdLoaderSetup) listFiles(dir string) error {
 		fname := strings.TrimSpace(f.Name())
 		lowerFName := strings.ToLower(fname)
 
-		info := fileInfo{path: path}
+		info := fileInfo{path: path, size: f.Size()}
 
 		var (
 			ftype         fileType

--- a/lightning/mydump/loader.go
+++ b/lightning/mydump/loader.go
@@ -17,6 +17,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"sort"
 	"strings"
 
 	"github.com/pingcap/errors"
@@ -137,6 +138,10 @@ var tableNameRegexp = regexp.MustCompile(`^([^.]+)\.(.*?)(?:\.[0-9]+)?$`)
 // files are visited in lexicographical order (note that this does not mean the
 // databases and tables in the end are ordered lexicographically since they may
 // be stored in different subdirectories).
+//
+// Will sort tables by table size, this means that the big table is imported
+// at the latest, which to avoid large table take a long time to import and block
+// small table to release index worker.
 func (s *mdLoaderSetup) setup(dir string) error {
 	/*
 		Mydumper file names format
@@ -187,6 +192,14 @@ func (s *mdLoaderSetup) setup(dir string) error {
 		}
 		tableMeta.DataFiles = append(tableMeta.DataFiles, fileInfo.path)
 		tableMeta.TotalSize += fileInfo.size
+	}
+
+	// Put the small table in the front of the slice which can avoid large table
+	// take a long time to import and block small table to release index worker.
+	for _, dbMeta := range s.loader.dbs {
+		sort.SliceStable(dbMeta.Tables, func(i, j int) bool {
+			return dbMeta.Tables[i].TotalSize < dbMeta.Tables[j].TotalSize
+		})
 	}
 
 	return nil

--- a/lightning/restore/restore.go
+++ b/lightning/restore/restore.go
@@ -1615,9 +1615,10 @@ outside:
 			return errors.Trace(err)
 		}
 
+		deliverKvStart := time.Now()
 		select {
 		case kvsCh <- deliveredKVs{kvs: kvs, offset: newOffset, rowID: rowID}:
-			continue
+			break
 		case <-ctx.Done():
 			return ctx.Err()
 		case deliverResult := <-deliverCompleteCh:
@@ -1626,6 +1627,7 @@ outside:
 			}
 			return errors.Trace(deliverResult.err)
 		}
+		metric.RowKVDeliverSecondsHistogram.Observe(time.Since(deliverKvStart).Seconds())
 	}
 
 	lastOffset, lastRowID := cr.parser.Pos()

--- a/lightning/restore/restore.go
+++ b/lightning/restore/restore.go
@@ -487,7 +487,7 @@ func (rc *RestoreController) restoreTables(ctx context.Context) error {
 		}
 		// Put the small table in the front of the slice which can avoid large table
 		// take a long time to import and block small table to release index worker.
-		sort.Slice(dbMeta.Tables, func(i, j int) bool {
+		sort.SliceStable(dbMeta.Tables, func(i, j int) bool {
 			return dbMeta.Tables[i].TotalSize < dbMeta.Tables[j].TotalSize
 		})
 		for _, tableMeta := range dbMeta.Tables {

--- a/lightning/restore/restore.go
+++ b/lightning/restore/restore.go
@@ -22,7 +22,6 @@ import (
 	"net/http"
 	"os"
 	"path"
-	"sort"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -485,11 +484,6 @@ func (rc *RestoreController) restoreTables(ctx context.Context) error {
 			common.AppLogger.Errorf("database %s not found in rc.dbInfos", dbMeta.Name)
 			continue
 		}
-		// Put the small table in the front of the slice which can avoid large table
-		// take a long time to import and block small table to release index worker.
-		sort.SliceStable(dbMeta.Tables, func(i, j int) bool {
-			return dbMeta.Tables[i].TotalSize < dbMeta.Tables[j].TotalSize
-		})
 		for _, tableMeta := range dbMeta.Tables {
 			tableInfo, ok := dbInfo.Tables[tableMeta.Name]
 			if !ok {


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-Lightning! Please read the [CONTRIBUTING](https://github.com/pingcap/tidb-lightning/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Put the large table in the front of the slice which can avoid large table take a long time to import and block small table to release index worker.

### What is changed and how it works?

Sorting tables before restore.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

Side effects

N/A

Related changes

N/A