### PR TITLE
tests: fix a test failure due to conflict between #145 and #158

### DIFF
--- a/lightning/restore/restore.go
+++ b/lightning/restore/restore.go
@@ -387,8 +387,8 @@ func (rc *RestoreController) listenCheckpointUpdates() {
 
 		// gofail: RETURN3:
 
-		// gofail: var KillIfImportedChunk struct{}
-		// if _, ok := scp.merger.(*ChunkCheckpointMerger); ok {
+		// gofail: var KillIfImportedChunk int
+		// if merger, ok := scp.merger.(*ChunkCheckpointMerger); ok && merger.Checksum.SumKVS() >= uint64(KillIfImportedChunk) {
 		// 	common.KillMySelf()
 		// }
 		// goto RETURN4

--- a/tests/checkpoint_chunks/run.sh
+++ b/tests/checkpoint_chunks/run.sh
@@ -102,7 +102,7 @@ rm -f "$TEST_DIR/cpch.pb"
 
 # Set the failpoint to kill the lightning instance as soon as one chunk is imported
 # If checkpoint does work, this should only kill $CHUNK_COUNT instances of lightnings.
-export GOFAIL_FAILPOINTS='github.com/pingcap/tidb-lightning/lightning/restore/FailIfImportedChunk=return'
+export GOFAIL_FAILPOINTS="github.com/pingcap/tidb-lightning/lightning/restore/FailIfImportedChunk=return($ROW_COUNT)"
 set +e
 for i in $(seq "$CHUNK_COUNT"); do
     echo "******** Importing Chunk using File checkpoint Now (step $i/$CHUNK_COUNT) ********"

--- a/tests/checkpoint_chunks/run.sh
+++ b/tests/checkpoint_chunks/run.sh
@@ -68,7 +68,7 @@ run_sql 'DROP DATABASE IF EXISTS tidb_lightning_checkpoint_test_cpch'
 
 # Set the failpoint to kill the lightning instance as soon as one chunk is imported, via signal mechanism
 # If checkpoint does work, this should only kill $CHUNK_COUNT instances of lightnings.
-export GOFAIL_FAILPOINTS='github.com/pingcap/tidb-lightning/lightning/restore/KillIfImportedChunk=return'
+export GOFAIL_FAILPOINTS="github.com/pingcap/tidb-lightning/lightning/restore/KillIfImportedChunk=return($ROW_COUNT)"
 
 for i in $(seq "$CHUNK_COUNT"); do
     echo "******** Importing Chunk Now (step $i/$CHUNK_COUNT) ********"


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-Lightning! Please read the [CONTRIBUTING](https://github.com/pingcap/tidb-lightning/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Fix this failure https://internal.pingcap.net/idc-jenkins/blue/organizations/jenkins/test_lightning_master/detail/test_lightning_master/25/pipeline

Problem was that #158 introduced a new test involving a failpoint which definition is changed in #145. There is no syntactical conflict between the two so the PRs merged cleanly, but the semantic conflict caused the integration test failure above.

### What is changed and how it works?

Updated the failpoint definition.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Integration test

Side effects

Related changes
