### PR TITLE
config: reduce default table-concurrency from 8 to 6

### DIFF
--- a/lightning/config/config.go
+++ b/lightning/config/config.go
@@ -156,7 +156,7 @@ func NewConfig() *Config {
 	return &Config{
 		App: Lightning{
 			RegionConcurrency: runtime.NumCPU(),
-			TableConcurrency:  8,
+			TableConcurrency:  6,
 			IndexConcurrency:  2,
 			IOConcurrency:     5,
 			CheckRequirements: true,

--- a/tidb-lightning.toml
+++ b/tidb-lightning.toml
@@ -10,7 +10,7 @@ pprof-port = 8289
 # index-concurrency controls the maximum handled index concurrently while reading Mydumper SQL files. It can affect the tikv-importer disk usage.
 index-concurrency = 2
 # table-concurrency controls the maximum handled tables concurrently while reading Mydumper SQL files. It can affect the tikv-importer memory usage.
-table-concurrency = 8
+table-concurrency = 6
 # region-concurrency changes the concurrency number of data. It is set to the number of logical CPU cores by default and needs no configuration.
 # In mixed configuration, you can set it to 75% of the size of logical CPU cores.
 # region-concurrency default to runtime.NumCPU()


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-Lightning! Please read the [CONTRIBUTING](https://github.com/pingcap/tidb-lightning/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

The current default table-concurrency is 8, meaning up to 8 data engines will be opened. Then the default index-concurrency is 2, so together up to 10 engines will be opened. But Importer's default max-open-engine is 8, so with the default settings we will hit the TooManyOpenEngines error.


### What is changed and how it works?

Reduce the default table-concurrency to 6.


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - No code

Side effects

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation
 - Need to update the `tidb-ansible` repository
