### PR TITLE
config,lightning: Implements server mode 

### DIFF
--- a/cmd/tidb-lightning/main.go
+++ b/cmd/tidb-lightning/main.go
@@ -14,14 +14,12 @@
 package main
 
 import (
-	"flag"
 	"fmt"
 	_ "net/http/pprof"
 	"os"
 	"os/signal"
 	"syscall"
 
-	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb-lightning/lightning"
 	"github.com/pingcap/tidb-lightning/lightning/config"
 	"github.com/pingcap/tidb-lightning/lightning/log"
@@ -38,16 +36,7 @@ func setGlobalVars() {
 func main() {
 	setGlobalVars()
 
-	cfg, err := config.LoadConfig(os.Args[1:])
-	switch errors.Cause(err) {
-	case nil:
-	case flag.ErrHelp:
-		os.Exit(0)
-	default:
-		fmt.Println("Failed to parse command flags: ", err)
-		os.Exit(1)
-	}
-
+	cfg := config.Must(config.LoadGlobalConfig(os.Args[1:], nil))
 	app := lightning.New(cfg)
 
 	sc := make(chan os.Signal, 1)
@@ -63,7 +52,14 @@ func main() {
 		app.Stop()
 	}()
 
-	err = app.Run()
+	go app.Serve()
+
+	var err error
+	if cfg.App.ServerMode {
+		err = app.RunServer()
+	} else {
+		err = app.RunOnce()
+	}
 	logger := log.L()
 	if err != nil {
 		logger.Error("tidb lightning encountered error", zap.Error(err))

--- a/cmd/tidb-lightning/main.go
+++ b/cmd/tidb-lightning/main.go
@@ -23,19 +23,10 @@ import (
 	"github.com/pingcap/tidb-lightning/lightning"
 	"github.com/pingcap/tidb-lightning/lightning/config"
 	"github.com/pingcap/tidb-lightning/lightning/log"
-	plan "github.com/pingcap/tidb/planner/core"
 	"go.uber.org/zap"
 )
 
-func setGlobalVars() {
-	// hardcode it
-	plan.SetPreparedPlanCache(true)
-	plan.PreparedPlanCacheCapacity = 10
-}
-
 func main() {
-	setGlobalVars()
-
 	cfg := config.Must(config.LoadGlobalConfig(os.Args[1:], nil))
 	app := lightning.New(cfg)
 

--- a/lightning/common/util_test.go
+++ b/lightning/common/util_test.go
@@ -22,6 +22,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/go-sql-driver/mysql"
 	. "github.com/pingcap/check"
@@ -65,10 +66,13 @@ func (s *utilSuite) TestGetJSON(c *C) {
 		handle(res, req)
 	}))
 	defer testServer.Close()
+
+	client := &http.Client{Timeout: time.Second}
+
 	response := TestPayload{}
-	err := common.GetJSON(http.DefaultClient, "http://not-exists", &response)
+	err := common.GetJSON(client, "http://not-exists", &response)
 	c.Assert(err, NotNil)
-	err = common.GetJSON(http.DefaultClient, testServer.URL, &response)
+	err = common.GetJSON(client, testServer.URL, &response)
 	c.Assert(err, IsNil)
 	c.Assert(request, DeepEquals, response)
 
@@ -76,7 +80,7 @@ func (s *utilSuite) TestGetJSON(c *C) {
 	handle = func(res http.ResponseWriter, req *http.Request) {
 		res.WriteHeader(http.StatusNoContent)
 	}
-	err = common.GetJSON(http.DefaultClient, testServer.URL, &response)
+	err = common.GetJSON(client, testServer.URL, &response)
 	c.Assert(err, NotNil)
 	c.Assert(err, ErrorMatches, ".*http status code != 200.*")
 }

--- a/lightning/config/config.go
+++ b/lightning/config/config.go
@@ -58,7 +58,7 @@ type DBStore struct {
 }
 
 type Config struct {
-	TaskID uint32 `toml:"-" json:"id"`
+	TaskID int64 `toml:"-" json:"id"`
 
 	App  Lightning `toml:"lightning" json:"lightning"`
 	TiDB DBStore   `toml:"tidb" json:"tidb"`

--- a/lightning/config/config.go
+++ b/lightning/config/config.go
@@ -15,9 +15,7 @@ package config
 
 import (
 	"encoding/json"
-	"flag"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"runtime"
 	"strings"
@@ -50,7 +48,6 @@ type DBStore struct {
 	StatusPort int    `toml:"status-port" json:"status-port"`
 	PdAddr     string `toml:"pd-addr" json:"pd-addr"`
 	StrSQLMode string `toml:"sql-mode" json:"sql-mode"`
-	LogLevel   string `toml:"log-level" json:"log-level"`
 
 	SQLMode mysql.SQLMode `toml:"-" json:"-"`
 
@@ -64,8 +61,6 @@ type Config struct {
 	App  Lightning `toml:"lightning" json:"lightning"`
 	TiDB DBStore   `toml:"tidb" json:"tidb"`
 
-	// not implemented yet.
-	// ProgressStore DBStore `toml:"progress-store" json:"progress-store"`
 	Checkpoint   Checkpoint          `toml:"checkpoint" json:"checkpoint"`
 	Mydumper     MydumperRuntime     `toml:"mydumper" json:"mydumper"`
 	BWList       *filter.Rules       `toml:"black-white-list" json:"black-white-list"`
@@ -73,9 +68,6 @@ type Config struct {
 	PostRestore  PostRestore         `toml:"post-restore" json:"post-restore"`
 	Cron         Cron                `toml:"cron" json:"cron"`
 	Routes       []*router.TableRule `toml:"routes" json:"routes"`
-
-	// command line flags
-	ConfigFile string `json:"config-file"`
 }
 
 func (c *Config) String() string {
@@ -87,12 +79,10 @@ func (c *Config) String() string {
 }
 
 type Lightning struct {
-	log.Config
 	TableConcurrency  int  `toml:"table-concurrency" json:"table-concurrency"`
 	IndexConcurrency  int  `toml:"index-concurrency" json:"index-concurrency"`
 	RegionConcurrency int  `toml:"region-concurrency" json:"region-concurrency"`
 	IOConcurrency     int  `toml:"io-concurrency" json:"io-concurrency"`
-	ProfilePort       int  `toml:"pprof-port" json:"pprof-port"`
 	CheckRequirements bool `toml:"check-requirements" json:"check-requirements"`
 }
 
@@ -171,7 +161,6 @@ func NewConfig() *Config {
 			Host:                       "127.0.0.1",
 			User:                       "root",
 			StatusPort:                 10080,
-			LogLevel:                   "error",
 			StrSQLMode:                 mysql.DefaultSQLMode,
 			BuildStatsConcurrency:      20,
 			DistSQLScanConcurrency:     100,
@@ -186,6 +175,7 @@ func NewConfig() *Config {
 			ReadBlockSize: ReadBlockSize,
 			CSV: CSVConfig{
 				Separator: ",",
+				Delimiter: `"`,
 			},
 		},
 		PostRestore: PostRestore{
@@ -194,89 +184,30 @@ func NewConfig() *Config {
 	}
 }
 
-func LoadConfig(args []string) (*Config, error) {
-	cfg := NewConfig()
-
-	fs := flag.NewFlagSet("lightning", flag.ContinueOnError)
-
-	// if both `-c` and `-config` are specified, the last one in the command line will take effect.
-	// the default value is assigned immediately after the StringVar() call,
-	// so it is fine to not give any default value for `-c`, to keep the `-h` page clean.
-	fs.StringVar(&cfg.ConfigFile, "c", "", "(deprecated alias of -config)")
-	fs.StringVar(&cfg.ConfigFile, "config", "", "tidb-lightning configuration file")
-	printVersion := fs.Bool("V", false, "print version of lightning")
-
-	logLevel := fs.String("L", "", `log level: info, debug, warn, error, fatal (default "info")`)
-	logFilePath := fs.String("log-file", "", "log file path")
-	tidbHost := fs.String("tidb-host", "", "TiDB server host")
-	tidbPort := fs.Int("tidb-port", 0, "TiDB server port (default 4000)")
-	tidbUser := fs.String("tidb-user", "", "TiDB user name to connect")
-	tidbStatusPort := fs.Int("tidb-status", 0, "TiDB server status port (default 10080)")
-	pdAddr := fs.String("pd-urls", "", "PD endpoint address")
-	dataSrcPath := fs.String("d", "", "Directory of the dump to import")
-	importerAddr := fs.String("importer", "", "address (host:port) to connect to tikv-importer")
-
-	if err := fs.Parse(args); err != nil {
-		return nil, errors.Trace(err)
-	}
-	if *printVersion {
-		fmt.Println(common.GetRawInfo())
-		return nil, flag.ErrHelp
+// LoadFromGlobal resets the current configuration to the global settings.
+func (cfg *Config) LoadFromGlobal(global *GlobalConfig) error {
+	if err := cfg.LoadFromTOML(global.ConfigFileContent); err != nil {
+		return err
 	}
 
-	if err := cfg.Load(); err != nil {
-		return nil, errors.Trace(err)
-	}
+	cfg.TiDB.Host = global.TiDB.Host
+	cfg.TiDB.Port = global.TiDB.Port
+	cfg.TiDB.User = global.TiDB.User
+	cfg.TiDB.StatusPort = global.TiDB.StatusPort
+	cfg.TiDB.PdAddr = global.TiDB.PdAddr
+	cfg.Mydumper.SourceDir = global.Mydumper.SourceDir
+	cfg.TikvImporter.Addr = global.TikvImporter.Addr
 
-	if *logLevel != "" {
-		cfg.App.Config.Level = *logLevel
-	}
-	if *logFilePath != "" {
-		cfg.App.Config.File = *logFilePath
-	}
-	if *tidbHost != "" {
-		cfg.TiDB.Host = *tidbHost
-	}
-	if *tidbPort != 0 {
-		cfg.TiDB.Port = *tidbPort
-	}
-	if *tidbStatusPort != 0 {
-		cfg.TiDB.StatusPort = *tidbStatusPort
-	}
-	if *tidbUser != "" {
-		cfg.TiDB.User = *tidbUser
-	}
-	if *pdAddr != "" {
-		cfg.TiDB.PdAddr = *pdAddr
-	}
-	if *dataSrcPath != "" {
-		cfg.Mydumper.SourceDir = *dataSrcPath
-	}
-	if *importerAddr != "" {
-		cfg.TikvImporter.Addr = *importerAddr
-	}
-
-	if err := cfg.Adjust(); err != nil {
-		return nil, err
-	}
-
-	return cfg, nil
+	return nil
 }
 
-func (cfg *Config) Load() error {
-	// use standard config if unspecified.
-	if cfg.ConfigFile == "" {
-		return nil
-	}
+// LoadFromTOML overwrites the current configuration by the TOML data
+func (cfg *Config) LoadFromTOML(data []byte) error {
+	return errors.Trace(toml.Unmarshal(data, cfg))
+}
 
-	data, err := ioutil.ReadFile(cfg.ConfigFile)
-	if err != nil {
-		return errors.Trace(err)
-	}
-	if err = toml.Unmarshal(data, cfg); err != nil {
-		return errors.Trace(err)
-	}
-
+// Adjust fixes the invalid or unspecified settings to reasonable valid values.
+func (cfg *Config) Adjust() error {
 	// Reject problematic CSV configurations.
 	csv := &cfg.Mydumper.CSV
 	if len(csv.Separator) != 1 {
@@ -300,6 +231,7 @@ func (cfg *Config) Load() error {
 		}
 	}
 
+	var err error
 	cfg.TiDB.SQLMode, err = mysql.GetSQLMode(cfg.TiDB.StrSQLMode)
 	if err != nil {
 		return errors.Annotate(err, "invalid config: `mydumper.tidb.sql_mode` must be a valid SQL_MODE")
@@ -313,13 +245,6 @@ func (cfg *Config) Load() error {
 			return errors.Trace(err)
 		}
 	}
-
-	return nil
-}
-
-// Adjust fixes the invalid or unspecified settings to reasonable valid values.
-func (cfg *Config) Adjust() error {
-	cfg.App.Config.Adjust()
 
 	// automatically determine the TiDB port & PD address from TiDB settings
 	if cfg.TiDB.Port <= 0 || len(cfg.TiDB.PdAddr) == 0 {

--- a/lightning/config/config.go
+++ b/lightning/config/config.go
@@ -58,6 +58,8 @@ type DBStore struct {
 }
 
 type Config struct {
+	TaskID uint32 `toml:"-" json:"id"`
+
 	App  Lightning `toml:"lightning" json:"lightning"`
 	TiDB DBStore   `toml:"tidb" json:"tidb"`
 

--- a/lightning/config/config_test.go
+++ b/lightning/config/config_test.go
@@ -377,3 +377,11 @@ func (s *configTestSuite) TestLoadConfig(c *C) {
 	result := taskCfg.String()
 	c.Assert(result, Matches, `.*"pd-addr":"172.16.30.11:2379,172.16.30.12:2379".*`)
 }
+
+func (s *configTestSuite) TestLoadFromInvalidConfig(c *C) {
+	taskCfg := config.NewConfig()
+	err := taskCfg.LoadFromGlobal(&config.GlobalConfig {
+		ConfigFileContent: []byte("invalid toml"),
+	})
+	c.Assert(err, ErrorMatches, "Near line 1.*")
+}

--- a/lightning/config/configlist.go
+++ b/lightning/config/configlist.go
@@ -1,0 +1,117 @@
+// Copyright 2019 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"container/list"
+	"context"
+	"sync"
+)
+
+// ConfigList is a goroutine-safe FIFO list of *Config, which supports removal
+// from the middle. The list is not expected to be very long.
+type ConfigList struct {
+	cond      *sync.Cond
+	nextID    uint32
+	taskIDMap map[uint32]*list.Element
+	nodes     list.List
+}
+
+// NewConfigList creates a new ConfigList instance.
+func NewConfigList() *ConfigList {
+	return &ConfigList{
+		cond:      sync.NewCond(new(sync.Mutex)),
+		taskIDMap: make(map[uint32]*list.Element),
+	}
+}
+
+// Push adds a configuration to the end of the list. The field `cfg.TaskID` will
+// be modified to include a unique ID to identify this task.
+func (cl *ConfigList) Push(cfg *Config) {
+	cl.cond.L.Lock()
+	defer cl.cond.L.Unlock()
+	id := cl.nextID
+	cl.nextID++
+	cfg.TaskID = id
+	cl.taskIDMap[id] = cl.nodes.PushBack(cfg)
+	cl.cond.Broadcast()
+}
+
+// Pop removes a configuration from the front of the list. If the list is empty,
+// this method will block until either another goroutines calls Push() or the
+// input context expired.
+//
+// If the context expired, the error field will contain the error from context.
+func (cl *ConfigList) Pop(ctx context.Context) (*Config, error) {
+	res := make(chan *Config)
+
+	go func() {
+		cl.cond.L.Lock()
+		defer cl.cond.L.Unlock()
+		for {
+			if front := cl.nodes.Front(); front != nil {
+				cfg := front.Value.(*Config)
+				delete(cl.taskIDMap, cfg.TaskID)
+				cl.nodes.Remove(front)
+				res <- cfg
+				break
+			}
+			cl.cond.Wait()
+		}
+	}()
+
+	select {
+	case cfg := <-res:
+		return cfg, nil
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+}
+
+// Remove removes a task from the list given its task ID. Returns true if a task
+// is successfully removed, false if the task ID did not exist.
+func (cl *ConfigList) Remove(taskID uint32) bool {
+	cl.cond.L.Lock()
+	defer cl.cond.L.Unlock()
+	element, ok := cl.taskIDMap[taskID]
+	if !ok {
+		return false
+	}
+	delete(cl.taskIDMap, taskID)
+	cl.nodes.Remove(element)
+	return true
+}
+
+// Get obtains a task from the list given its task ID. If the task ID did not
+// exist, the returned bool field will be false.
+func (cl *ConfigList) Get(taskID uint32) (*Config, bool) {
+	cl.cond.L.Lock()
+	defer cl.cond.L.Unlock()
+	element, ok := cl.taskIDMap[taskID]
+	if !ok {
+		return nil, false
+	}
+	return element.Value.(*Config), true
+}
+
+// AllIDs returns a list of all task IDs in the list.
+func (cl *ConfigList) AllIDs() []uint32 {
+	cl.cond.L.Lock()
+	defer cl.cond.L.Unlock()
+	res := make([]uint32, 0, len(cl.taskIDMap))
+	for taskID := range cl.taskIDMap {
+		res = append(res, taskID)
+	}
+	return res
+}

--- a/lightning/config/configlist_test.go
+++ b/lightning/config/configlist_test.go
@@ -1,0 +1,104 @@
+// Copyright 2019 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config_test
+
+import (
+	"context"
+	"time"
+
+	. "github.com/pingcap/check"
+	"github.com/pingcap/tidb-lightning/lightning/config"
+)
+
+var _ = Suite(&configListTestSuite{})
+
+type configListTestSuite struct{}
+
+func (s *configListTestSuite) TestNormalPushPop(c *C) {
+	cl := config.NewConfigList()
+
+	cl.Push(&config.Config{TikvImporter: config.TikvImporter{Addr: "1.1.1.1:1111"}})
+	cl.Push(&config.Config{TikvImporter: config.TikvImporter{Addr: "2.2.2.2:2222"}})
+
+	startTime := time.Now()
+	cfg, err := cl.Pop(context.Background()) // these two should never block.
+	c.Assert(time.Since(startTime), Less, 100*time.Millisecond)
+	c.Assert(err, IsNil)
+	c.Assert(cfg.TikvImporter.Addr, Equals, "1.1.1.1:1111")
+
+	startTime = time.Now()
+	cfg, err = cl.Pop(context.Background())
+	c.Assert(time.Since(startTime), Less, 100*time.Millisecond)
+	c.Assert(err, IsNil)
+	c.Assert(cfg.TikvImporter.Addr, Equals, "2.2.2.2:2222")
+
+	go func() {
+		time.Sleep(400 * time.Millisecond)
+		cl.Push(&config.Config{TikvImporter: config.TikvImporter{Addr: "3.3.3.3:3333"}})
+	}()
+
+	startTime = time.Now()
+	cfg, err = cl.Pop(context.Background()) // this should block for ≥400ms
+	c.Assert(time.Since(startTime), GreaterEqual, 400*time.Millisecond)
+	c.Assert(err, IsNil)
+	c.Assert(cfg.TikvImporter.Addr, Equals, "3.3.3.3:3333")
+}
+
+func (s *configListTestSuite) TestContextCancel(c *C) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cl := config.NewConfigList()
+
+	go func() {
+		time.Sleep(400 * time.Millisecond)
+		cancel()
+	}()
+
+	startTime := time.Now()
+	_, err := cl.Pop(ctx)
+	c.Assert(time.Since(startTime), GreaterEqual, 400*time.Millisecond)
+	c.Assert(err, Equals, context.Canceled)
+}
+
+func (s *configListTestSuite) TestGetRemove(c *C) {
+	cl := config.NewConfigList()
+
+	cfg1 := &config.Config{TikvImporter: config.TikvImporter{Addr: "1.1.1.1:1111"}}
+	cl.Push(cfg1)
+	cfg2 := &config.Config{TikvImporter: config.TikvImporter{Addr: "2.2.2.2:2222"}}
+	cl.Push(cfg2)
+	cfg3 := &config.Config{TikvImporter: config.TikvImporter{Addr: "3.3.3.3:3333"}}
+	cl.Push(cfg3)
+
+	cfg, ok := cl.Get(cfg2.TaskID)
+	c.Assert(ok, IsTrue)
+	c.Assert(cfg, Equals, cfg2)
+	_, ok = cl.Get(cfg3.TaskID + 1000)
+	c.Assert(ok, IsFalse)
+
+	ok = cl.Remove(cfg2.TaskID)
+	c.Assert(ok, IsTrue)
+	ok = cl.Remove(cfg3.TaskID + 1000)
+	c.Assert(ok, IsFalse)
+	_, ok = cl.Get(cfg2.TaskID)
+	c.Assert(ok, IsFalse)
+
+	var err error
+	cfg, err = cl.Pop(context.Background())
+	c.Assert(err, IsNil)
+	c.Assert(cfg, Equals, cfg1)
+
+	cfg, err = cl.Pop(context.Background())
+	c.Assert(err, IsNil)
+	c.Assert(cfg, Equals, cfg3)
+}

--- a/lightning/config/global.go
+++ b/lightning/config/global.go
@@ -1,0 +1,183 @@
+// Copyright 2019 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"flag"
+	"fmt"
+	"io/ioutil"
+	"os"
+
+	"github.com/BurntSushi/toml"
+	"github.com/pingcap/errors"
+	"github.com/pingcap/tidb-lightning/lightning/common"
+	"github.com/pingcap/tidb-lightning/lightning/log"
+)
+
+type GlobalLightning struct {
+	log.Config
+	StatusAddr string `toml:"status-addr" json:"status-addr"`
+	ServerMode bool   `toml:"server-mode" json:"server-mode"`
+
+	// The legacy alias for setting "status-addr"
+	PProfPort int `toml:"pprof-port" json:"-"`
+}
+
+type GlobalTiDB struct {
+	Host       string `toml:"host" json:"host"`
+	Port       int    `toml:"port" json:"port"`
+	User       string `toml:"user" json:"user"`
+	StatusPort int    `toml:"status-port" json:"status-port"`
+	PdAddr     string `toml:"pd-addr" json:"pd-addr"`
+	LogLevel   string `toml:"log-level" json:"log-level"`
+}
+
+type GlobalMydumper struct {
+	SourceDir string `toml:"data-source-dir" json:"data-source-dir"`
+}
+
+type GlobalImporter struct {
+	Addr string `toml:"addr" json:"addr"`
+}
+
+type GlobalConfig struct {
+	App          GlobalLightning `toml:"lightning" json:"lightning"`
+	TiDB         GlobalTiDB      `toml:"tidb" json:"tidb"`
+	Mydumper     GlobalMydumper  `toml:"mydumper" json:"mydumper"`
+	TikvImporter GlobalImporter  `toml:"tikv-importer" json:"tikv-importer"`
+
+	ConfigFileContent []byte
+}
+
+func NewGlobalConfig() *GlobalConfig {
+	return &GlobalConfig{
+		App: GlobalLightning{
+			ServerMode: false,
+		},
+		TiDB: GlobalTiDB{
+			Host:       "127.0.0.1",
+			User:       "root",
+			StatusPort: 10080,
+			LogLevel:   "error",
+		},
+	}
+}
+
+// Must should be called after LoadGlobalConfig(). If LoadGlobalConfig() returns
+// any error, this function will exit the program with an appropriate exit code.
+func Must(cfg *GlobalConfig, err error) *GlobalConfig {
+	switch errors.Cause(err) {
+	case nil:
+	case flag.ErrHelp:
+		os.Exit(0)
+	default:
+		fmt.Println("Failed to parse command flags: ", err)
+		os.Exit(2)
+	}
+	return cfg
+}
+
+// LoadGlobalConfig reads the arguments and fills in the GlobalConfig.
+func LoadGlobalConfig(args []string, extraFlags func(*flag.FlagSet)) (*GlobalConfig, error) {
+	cfg := NewGlobalConfig()
+	fs := flag.NewFlagSet("", flag.ContinueOnError)
+
+	// if both `-c` and `-config` are specified, the last one in the command line will take effect.
+	// the default value is assigned immediately after the StringVar() call,
+	// so it is fine to not give any default value for `-c`, to keep the `-h` page clean.
+	var configFilePath string
+	fs.StringVar(&configFilePath, "c", "", "(deprecated alias of -config)")
+	fs.StringVar(&configFilePath, "config", "", "tidb-lightning configuration file")
+	printVersion := fs.Bool("V", false, "print version of lightning")
+
+	logLevel := fs.String("L", "", `log level: info, debug, warn, error, fatal (default "info")`)
+	logFilePath := fs.String("log-file", "", "log file path")
+	tidbHost := fs.String("tidb-host", "", "TiDB server host")
+	tidbPort := fs.Int("tidb-port", 0, "TiDB server port (default 4000)")
+	tidbUser := fs.String("tidb-user", "", "TiDB user name to connect")
+	tidbStatusPort := fs.Int("tidb-status", 0, "TiDB server status port (default 10080)")
+	pdAddr := fs.String("pd-urls", "", "PD endpoint address")
+	dataSrcPath := fs.String("d", "", "Directory of the dump to import")
+	importerAddr := fs.String("importer", "", "address (host:port) to connect to tikv-importer")
+
+	statusAddr := fs.String("status-addr", "", "the Lightning server address")
+	serverMode := fs.Bool("server-mode", false, "start Lightning in server mode, wait for multiple tasks instead of starting immediately")
+
+	if extraFlags != nil {
+		extraFlags(fs)
+	}
+
+	if err := fs.Parse(args); err != nil {
+		return nil, errors.Trace(err)
+	}
+	if *printVersion {
+		fmt.Println(common.GetRawInfo())
+		return nil, flag.ErrHelp
+	}
+
+	if len(configFilePath) > 0 {
+		data, err := ioutil.ReadFile(configFilePath)
+		if err != nil {
+			return nil, errors.Annotatef(err, "Cannot read config file `%s`", configFilePath)
+		}
+		if err = toml.Unmarshal(data, cfg); err != nil {
+			return nil, errors.Annotatef(err, "Cannot parse config file `%s`", configFilePath)
+		}
+		cfg.ConfigFileContent = data
+	}
+
+	if *logLevel != "" {
+		cfg.App.Config.Level = *logLevel
+	}
+	if *logFilePath != "" {
+		cfg.App.Config.File = *logFilePath
+	}
+	if *tidbHost != "" {
+		cfg.TiDB.Host = *tidbHost
+	}
+	if *tidbPort != 0 {
+		cfg.TiDB.Port = *tidbPort
+	}
+	if *tidbStatusPort != 0 {
+		cfg.TiDB.StatusPort = *tidbStatusPort
+	}
+	if *tidbUser != "" {
+		cfg.TiDB.User = *tidbUser
+	}
+	if *pdAddr != "" {
+		cfg.TiDB.PdAddr = *pdAddr
+	}
+	if *dataSrcPath != "" {
+		cfg.Mydumper.SourceDir = *dataSrcPath
+	}
+	if *importerAddr != "" {
+		cfg.TikvImporter.Addr = *importerAddr
+	}
+	if *serverMode {
+		cfg.App.ServerMode = true
+	}
+	if *statusAddr != "" {
+		cfg.App.StatusAddr = *statusAddr
+	}
+	if cfg.App.StatusAddr == "" && cfg.App.PProfPort != 0 {
+		cfg.App.StatusAddr = fmt.Sprintf(":%d", cfg.App.PProfPort)
+	}
+
+	if cfg.App.StatusAddr == "" && cfg.App.ServerMode {
+		return nil, errors.New("If server-mode is enabled, the status-addr must be a valid listen address")
+	}
+
+	cfg.App.Config.Adjust()
+	return cfg, nil
+}

--- a/lightning/config/global.go
+++ b/lightning/config/global.go
@@ -30,7 +30,8 @@ type GlobalLightning struct {
 	StatusAddr string `toml:"status-addr" json:"status-addr"`
 	ServerMode bool   `toml:"server-mode" json:"server-mode"`
 
-	// The legacy alias for setting "status-addr"
+	// The legacy alias for setting "status-addr". The value should always the
+	// same as StatusAddr, and will not be published in the JSON encoding.
 	PProfPort int `toml:"pprof-port" json:"-"`
 }
 

--- a/lightning/lightning.go
+++ b/lightning/lightning.go
@@ -16,9 +16,10 @@ package lightning
 import (
 	"context"
 	"fmt"
+	"io/ioutil"
 	"net/http"
+	"os"
 	"runtime"
-	"sync"
 
 	"github.com/pingcap/errors"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
@@ -32,67 +33,96 @@ import (
 )
 
 type Lightning struct {
-	cfg      *config.Config
-	ctx      context.Context
-	shutdown context.CancelFunc
-
-	wg sync.WaitGroup
+	globalCfg *config.GlobalConfig
+	taskCfgs  chan *config.Config
+	ctx       context.Context
+	shutdown  context.CancelFunc
+	server    http.Server
 }
 
-func initEnv(cfg *config.Config) error {
-	if err := log.InitLogger(&cfg.App.Config, cfg.TiDB.LogLevel); err != nil {
-		return errors.Trace(err)
-	}
-
-	if cfg.App.ProfilePort > 0 {
-		go func() {
-			http.Handle("/metrics", promhttp.Handler())
-			err := http.ListenAndServe(fmt.Sprintf(":%d", cfg.App.ProfilePort), nil)
-			log.L().Info("stopped HTTP server", log.ShortError(err))
-		}()
-	}
-
-	return nil
+func initEnv(cfg *config.GlobalConfig) error {
+	return log.InitLogger(&cfg.App.Config, cfg.TiDB.LogLevel)
 }
 
-func New(cfg *config.Config) *Lightning {
-	initEnv(cfg)
+func New(globalCfg *config.GlobalConfig) *Lightning {
+	if err := initEnv(globalCfg); err != nil {
+		fmt.Println("Failed to initialize environment:", err)
+		os.Exit(1)
+	}
+
+	runtime.GOMAXPROCS(runtime.NumCPU())
 
 	ctx, shutdown := context.WithCancel(context.Background())
-
 	return &Lightning{
-		cfg:      cfg,
-		ctx:      ctx,
-		shutdown: shutdown,
+		globalCfg: globalCfg,
+		ctx:       ctx,
+		shutdown:  shutdown,
 	}
 }
 
-func (l *Lightning) Run() error {
-	runtime.GOMAXPROCS(runtime.NumCPU())
-	common.PrintInfo("lightning", func() {
-		log.L().Info("cfg", zap.Stringer("cfg", l.cfg))
+func (l *Lightning) Serve() {
+	if len(l.globalCfg.App.StatusAddr) == 0 {
+		return
+	}
+
+	http.Handle("/metrics", promhttp.Handler())
+	http.HandleFunc("/tasks", func(w http.ResponseWriter, req *http.Request) {
+		l.handleNewTask(w, req)
 	})
 
-	l.wg.Add(1)
-	var err error
-	go func() {
-		defer l.wg.Done()
-		err = l.run()
-	}()
-	l.wg.Wait()
-	return errors.Trace(err)
+	l.server.Addr = l.globalCfg.App.StatusAddr
+	err := l.server.ListenAndServe()
+	log.L().Info("stopped HTTP server", log.ShortError(err))
 }
 
-func (l *Lightning) run() error {
+// Run Lightning using the global config as the same as the task config.
+func (l *Lightning) RunOnce() error {
+	cfg := config.NewConfig()
+	if err := cfg.LoadFromGlobal(l.globalCfg); err != nil {
+		return err
+	}
+	if err := cfg.Adjust(); err != nil {
+		return err
+	}
+	return l.run(cfg)
+}
+
+func (l *Lightning) RunServer() error {
+	var finalErr error
+	l.taskCfgs = make(chan *config.Config, 64)
+
+	log.L().Info("Lightning server is running, post to /tasks to start an import task")
+
+	for {
+		select {
+		case <-l.ctx.Done():
+			return l.ctx.Err()
+		case task := <-l.taskCfgs:
+			if task == nil {
+				return finalErr
+			}
+			err := l.run(task)
+			if err != nil {
+				finalErr = err
+			}
+		}
+	}
+}
+
+func (l *Lightning) run(taskCfg *config.Config) error {
+	common.PrintInfo("lightning", func() {
+		log.L().Info("cfg", zap.Stringer("cfg", taskCfg))
+	})
+
 	loadTask := log.L().Begin(zap.InfoLevel, "load data source")
-	mdl, err := mydump.NewMyDumpLoader(l.cfg)
+	mdl, err := mydump.NewMyDumpLoader(taskCfg)
 	loadTask.End(zap.ErrorLevel, err)
 	if err != nil {
 		return errors.Trace(err)
 	}
 
 	dbMetas := mdl.GetDatabases()
-	procedure, err := restore.NewRestoreController(l.ctx, dbMetas, l.cfg)
+	procedure, err := restore.NewRestoreController(l.ctx, dbMetas, taskCfg)
 	if err != nil {
 		log.L().Error("restore failed", log.ShortError(err))
 		return errors.Trace(err)
@@ -105,6 +135,52 @@ func (l *Lightning) run() error {
 }
 
 func (l *Lightning) Stop() {
+	if err := l.server.Shutdown(l.ctx); err != nil {
+		log.L().Warn("failed to shutdown HTTP server", log.ShortError(err))
+	}
 	l.shutdown()
-	l.wg.Wait()
+}
+
+func (l *Lightning) handleNewTask(w http.ResponseWriter, req *http.Request) {
+	if req.Method != http.MethodPost {
+		w.Header().Set("Allow", http.MethodPost)
+		http.Error(w, "only POST is allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	cfgs := l.taskCfgs
+	if cfgs == nil {
+		w.Header().Set("Cache-Control", "no-store")
+		http.Error(w, "server-mode not enabled", http.StatusNotImplemented)
+		return
+	}
+
+	data, err := ioutil.ReadAll(req.Body)
+	if err != nil {
+		http.Error(w, fmt.Sprintf("cannot read request: %v", err), http.StatusBadRequest)
+		return
+	}
+	log.L().Debug("received task config", zap.ByteString("content", data))
+
+	cfg := config.NewConfig()
+	if err = cfg.LoadFromGlobal(l.globalCfg); err != nil {
+		http.Error(w, fmt.Sprintf("cannot restore from global config: %v", err), http.StatusInternalServerError)
+		return
+	}
+	if err = cfg.LoadFromTOML(data); err != nil {
+		http.Error(w, fmt.Sprintf("cannot parse task (must be TOML): %v", err), http.StatusBadRequest)
+		return
+	}
+	if err = cfg.Adjust(); err != nil {
+		http.Error(w, fmt.Sprintf("invalid task configuration: %v", err), http.StatusBadRequest)
+		return
+	}
+
+	select {
+	case cfgs <- cfg:
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("task queued"))
+	default:
+		http.Error(w, "task queue overflowed, please try again later", http.StatusServiceUnavailable)
+	}
 }

--- a/lightning/lightning.go
+++ b/lightning/lightning.go
@@ -19,7 +19,6 @@ import (
 	"io/ioutil"
 	"net/http"
 	"os"
-	"runtime"
 
 	"github.com/pingcap/errors"
 	"github.com/pingcap/failpoint"
@@ -50,8 +49,6 @@ func New(globalCfg *config.GlobalConfig) *Lightning {
 		fmt.Println("Failed to initialize environment:", err)
 		os.Exit(1)
 	}
-
-	runtime.GOMAXPROCS(runtime.NumCPU())
 
 	ctx, shutdown := context.WithCancel(context.Background())
 	return &Lightning{
@@ -113,11 +110,11 @@ func (l *Lightning) RunServer() error {
 var taskCfgRecorderKey struct{}
 
 func (l *Lightning) run(taskCfg *config.Config) error {
-	failpoint.Inject("SkipRunTask", func() {
+	failpoint.Inject("SkipRunTask", func() error {
 		if recorder, ok := l.ctx.Value(&taskCfgRecorderKey).(chan *config.Config); ok {
 			recorder <- taskCfg
 		}
-		failpoint.Return(nil)
+		return nil
 	})
 
 	common.PrintInfo("lightning", func() {

--- a/lightning/lightning.go
+++ b/lightning/lightning.go
@@ -160,8 +160,8 @@ func (l *Lightning) handleTask(w http.ResponseWriter, req *http.Request) {
 
 func (l *Lightning) handleGetTask(w http.ResponseWriter) {
 	var response struct {
-		Enabled   bool     `json:"enabled"`
-		QueuedIDs []uint32 `json:"queue"`
+		Enabled   bool    `json:"enabled"`
+		QueuedIDs []int64 `json:"queue"`
 	}
 
 	response.Enabled = l.taskCfgs != nil
@@ -180,7 +180,7 @@ func (l *Lightning) handlePostTask(w http.ResponseWriter, req *http.Request) {
 		Error string `json:"error"`
 	}
 	type taskResponse struct {
-		ID uint32 `json:"id"`
+		ID int64 `json:"id"`
 	}
 
 	if l.taskCfgs == nil {

--- a/tidb-lightning.toml
+++ b/tidb-lightning.toml
@@ -1,8 +1,18 @@
 ### tidb-lightning configuartion
 [lightning]
 
-# background profile for debuging ( 0 to disable )
-pprof-port = 8289
+# Listening address for the HTTP server (set to empty string to disable).
+# The server is responsible for the web interface, submitting import tasks,
+# serving Prometheus metrics and exposing debug profiling data.
+status-addr = ":8289"
+
+# Toggle server mode.
+# If "false", running Lightning will immediately start the import job, and exits
+# after the job is finished.
+# If "true", running Lightning will wait for user to submit tasks, via the HTTP API
+# (`curl http://lightning-ip:8289/tasks --data-binary @tidb-lightning.toml`).
+# The program will keep running and waiting for more tasks, until receiving the SIGINT signal.
+server-mode = false
 
 # check if the cluster satisfies the minimum requirement before starting
 # check-requirements = true


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-Lightning! Please read the [CONTRIBUTING](https://github.com/pingcap/tidb-lightning/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

As a prerequisite of the "web interface", we'd like to have Lightning keep running even after import is finished. 

The behavior overlaps with a feature request which turns Lightning into a server, which we could submit tasks to it (similar to DM-master). The conversion is straightforward, so why not 🙃.

### What is changed and how it works?

1. Split config into two classes: "Global config" and "Task config" (both  are subset of `tidb-lightning.toml`, unlike DM task settings). 
    * Also refactored the existing argument parsing code to cut down the code duplication.

2. Added an HTTP endpoint which allows user to upload a Task config toml. 

3. Changed the public `Run()` method to loop for those uploaded tasks in server mode. Essentially like this:

    ```go
    func Run() {
        if !ServerMode {
            run(globalConfig)
        } else {
            for taskConfig := range uploadedTaskConfigs {
                run(taskConfig)
            }
        }
    }
    ```

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

Side effects

 - Increased code complexity

Related changes

 - Need to update the documentation 
 - Need to be included in the release note 