### PR TITLE
tests,web: exclude these directories from the Go module

### DIFF
--- a/tests/go.mod
+++ b/tests/go.mod
@@ -1,0 +1,1 @@
+// Exclude this directory from the Go module

--- a/web/go.mod
+++ b/web/go.mod
@@ -1,0 +1,1 @@
+// Exclude this directory from the Go module


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-Lightning! Please read the [CONTRIBUTING](https://github.com/pingcap/tidb-lightning/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Currently when trying to import tidb-lightning externally on macOS we'll get a "malformed file path" error due to a `` ` `` in the filename of a test case. Since a Go module shouldn't need the integrated tests anyway, we just ignore these non-source folders instead of trying to fix Go 🤷.

### What is changed and how it works?

Recommended in https://github.com/golang/go/wiki/Modules#can-an-additional-gomod-exclude-unnecessary-content-do-modules-have-the-equivalent-of-a-gitignore-file, we include an empty `go.mod` in the `tests/` and `web/` folder so they're no longer part of the Go module.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - No code

Side effects

Related changes
