### PR TITLE
lightning/restore: fix ColumnPermutation calculation

### DIFF
--- a/lightning/restore/restore.go
+++ b/lightning/restore/restore.go
@@ -1218,7 +1218,7 @@ func (t *TableRestore) initializeColumns(columns []string, ccp *ChunkCheckpoint)
 	} else {
 		columnMap := make(map[string]int)
 		for i, column := range columns {
-			columnMap[column] = i
+			columnMap[strings.ToLower(column)] = i
 		}
 		for _, colInfo := range t.tableInfo.Core.Columns {
 			if i, ok := columnMap[colInfo.Name.L]; ok {


### PR DESCRIPTION
Signed-off-by: Lonng <heng@lonng.org>

<!--
Thank you for contributing to TiDB-Lightning! Please read the [CONTRIBUTING](https://github.com/pingcap/tidb-lightning/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Fix the `initializeColumns` method.

Related changes

 - Need to cherry-pick to the release branch