### PR TITLE
restore: fix gc life time not recovered after table restore

### DIFF
--- a/lightning/restore/restore.go
+++ b/lightning/restore/restore.go
@@ -496,7 +496,7 @@ func (rc *RestoreController) restoreTables(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	ctx2 := context.WithValue(ctx, gcLifeTimeKey, oriGCLifeTime)
+	ctx2 := context.WithValue(ctx, &gcLifeTimeKey, oriGCLifeTime)
 	for i := 0; i < rc.cfg.App.IndexConcurrency; i++ {
 		go func() {
 			for task := range taskCh {
@@ -1364,7 +1364,7 @@ func increaseGCLifeTime(ctx context.Context, db *sql.DB) (oriGCLifeTime string, 
 	// checksum command usually takes a long time to execute,
 	// so here need to increase the gcLifeTime for single transaction.
 	// try to get gcLifeTime from context first.
-	gcLifeTime, ok := ctx.Value(gcLifeTimeKey).(string)
+	gcLifeTime, ok := ctx.Value(&gcLifeTimeKey).(string)
 	if !ok {
 		oriGCLifeTime, err = ObtainGCLifeTime(ctx, db)
 		if err != nil {

--- a/tests/concurrent-restore/config.toml
+++ b/tests/concurrent-restore/config.toml
@@ -9,7 +9,7 @@ level = "info"
 addr = "127.0.0.1:8808"
 
 [mydumper]
-data-source-dir = "/tmp/lightning_test_result/restore.mydump"
+data-source-dir = "/tmp/lightning_test_result/restore_conc.mydump"
 
 [tidb]
 host = "127.0.0.1"

--- a/tests/concurrent-restore/config.toml
+++ b/tests/concurrent-restore/config.toml
@@ -1,0 +1,23 @@
+[lightning]
+table-concurrency = 4
+index-concurrency = 4
+check-requirements = false
+file = "/tmp/lightning_test_result/lightning.log"
+level = "info"
+
+[tikv-importer]
+addr = "127.0.0.1:8808"
+
+[mydumper]
+data-source-dir = "/tmp/lightning_test_result/restore.mydump"
+
+[tidb]
+host = "127.0.0.1"
+user = "root"
+status-port = 10080
+log-level = "error"
+
+[post-restore]
+checksum = true
+compact = false
+analyze = false

--- a/tests/concurrent-restore/run.sh
+++ b/tests/concurrent-restore/run.sh
@@ -1,0 +1,49 @@
+#!/bin/sh
+#
+# Copyright 2019 PingCAP, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -eu
+
+# Populate the mydumper source
+DBPATH="$TEST_DIR/restore.mydump"
+TABLE_COUNT=20
+
+mkdir -p $DBPATH
+echo 'CREATE DATABASE restore_conc;' > "$DBPATH/restore_conc-schema-create.sql"
+for i in $(seq "$TABLE_COUNT"); do
+    echo "CREATE TABLE tbl$i(i TINYINT);" > "$DBPATH/restore_conc.tbl$i-schema.sql"
+    echo "INSERT INTO tbl$i VALUES (1);" > "$DBPATH/restore_conc.tbl$i.sql"
+done
+
+run_sql 'select VARIABLE_VALUE from mysql.tidb where VARIABLE_NAME = "tikv_gc_life_time"';
+ORIGINAL_TIKV_GC_LIFE_TIME=$(tail -n 1 "$TEST_DIR/sql_res.$TEST_NAME.txt" | awk '{print $(NF)}')
+
+# Count OpenEngine and CloseEngine events.
+# add a delay after increasing tikv_gc_life_time, in order to increase confilct possibility
+export GO_FAILPOINTS='github.com/pingcap/tidb-lightning/lightning/restore/IncreaseGCUpdateDuration=sleep(200)'
+
+# Start importing
+run_sql 'DROP DATABASE IF EXISTS restore_conc'
+run_lightning
+echo "Import finished"
+
+# Verify all data are imported
+for i in $(seq "$TABLE_COUNT"); do
+    run_sql "SELECT sum(i) FROM restore_conc.tbl$i;"
+    check_contains 'sum(i): 1'
+done
+
+# check tikv_gc_life_time is recovered to the original value
+run_sql 'select VARIABLE_VALUE from mysql.tidb where VARIABLE_NAME = "tikv_gc_life_time"';
+check_contains "VARIABLE_VALUE: $ORIGINAL_TIKV_GC_LIFE_TIME"

--- a/tests/concurrent-restore/run.sh
+++ b/tests/concurrent-restore/run.sh
@@ -17,7 +17,7 @@ set -eu
 
 # Populate the mydumper source
 DBPATH="$TEST_DIR/restore.mydump"
-TABLE_COUNT=20
+TABLE_COUNT=8
 
 mkdir -p $DBPATH
 echo 'CREATE DATABASE restore_conc;' > "$DBPATH/restore_conc-schema-create.sql"
@@ -29,7 +29,6 @@ done
 run_sql 'select VARIABLE_VALUE from mysql.tidb where VARIABLE_NAME = "tikv_gc_life_time"';
 ORIGINAL_TIKV_GC_LIFE_TIME=$(tail -n 1 "$TEST_DIR/sql_res.$TEST_NAME.txt" | awk '{print $(NF)}')
 
-# Count OpenEngine and CloseEngine events.
 # add a delay after increasing tikv_gc_life_time, in order to increase confilct possibility
 export GO_FAILPOINTS='github.com/pingcap/tidb-lightning/lightning/restore/IncreaseGCUpdateDuration=sleep(200)'
 

--- a/tests/concurrent-restore/run.sh
+++ b/tests/concurrent-restore/run.sh
@@ -16,7 +16,7 @@
 set -eu
 
 # Populate the mydumper source
-DBPATH="$TEST_DIR/restore.mydump"
+DBPATH="$TEST_DIR/restore_conc.mydump"
 TABLE_COUNT=8
 
 mkdir -p $DBPATH


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-Lightning! Please read the [CONTRIBUTING](https://github.com/pingcap/tidb-lightning/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

feedback from DBA, sometimes after import data successfully with lightning, `tikv_gc_life_time` remains `100h0m0s` and not recovers to the original value (often `10m0s`).

### What is changed and how it works?

This is caused by concurrent execution of `restore table`, and the `tikv_gc_life_time` update timeline maybe intersect like following:

```
thread1:  get gc=10m ---> set gc=100h -----> checksum ------> rollback gc to 10m
thread2:  -------------------------------> get gc=100h -----> checksum -----> rollback gc to 100h
```
We query `tikv_gc_life_time` from downstream database before execution of restore table once

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test


Related changes

 - Need to cherry-pick to the release branch
