### PR TITLE
cmd: do not exit(1) if failed to sync log

### DIFF
--- a/cmd/tidb-lightning/main.go
+++ b/cmd/tidb-lightning/main.go
@@ -66,7 +66,7 @@ func main() {
 		fmt.Fprintln(os.Stderr, "sync log failed", syncErr)
 	}
 
-	if err != nil || syncErr != nil {
+	if err != nil {
 		os.Exit(1)
 	}
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-Lightning! Please read the [CONTRIBUTING](https://github.com/pingcap/tidb-lightning/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Even if the log file failed to sync (usually caused by log file = /dev/stdout), it shouldn't cause the program to exit with failure.

### What is changed and how it works?

Remove the condition that sync log fail causing exit(1).

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)
    * Run the program

Side effects

Related changes

 - Need to cherry-pick to the release branch (2.1)