### PR TITLE
checkpoint: fix empty map become nil after unmarshall

### DIFF
--- a/lightning/checkpoints/checkpoints.go
+++ b/lightning/checkpoints/checkpoints.go
@@ -741,7 +741,25 @@ func NewFileCheckpointsDB(path string) *FileCheckpointsDB {
 	// ignore all errors -- file maybe not created yet (and it is fine).
 	content, err := ioutil.ReadFile(path)
 	if err == nil {
-		cpdb.checkpoints.Unmarshal(content)
+		err2 := cpdb.checkpoints.Unmarshal(content)
+		if err2 != nil {
+			log.L().Error("checkpoint file is broken", zap.String("path", path), zap.Error(err2))
+		}
+		// FIXME: patch for empty map may need initialize manually, because currently
+		// FIXME: a map of zero size -> marshall -> unmarshall -> become nil, see checkpoint_test.go
+		if cpdb.checkpoints.Checkpoints == nil {
+			cpdb.checkpoints.Checkpoints = map[string]*TableCheckpointModel{}
+		}
+		for _, table := range cpdb.checkpoints.Checkpoints {
+			if (*table).Engines == nil {
+				(*table).Engines = map[int32]*EngineCheckpointModel{}
+			}
+			for _, engine := range (*table).Engines {
+				if (*engine).Chunks == nil {
+					(*engine).Chunks = map[string]*ChunkCheckpointModel{}
+				}
+			}
+		}
 	} else {
 		log.L().Info("open checkpoint file failed, going to create a new one",
 			zap.String("path", path),

--- a/lightning/checkpoints/checkpoints.go
+++ b/lightning/checkpoints/checkpoints.go
@@ -751,12 +751,12 @@ func NewFileCheckpointsDB(path string) *FileCheckpointsDB {
 			cpdb.checkpoints.Checkpoints = map[string]*TableCheckpointModel{}
 		}
 		for _, table := range cpdb.checkpoints.Checkpoints {
-			if (*table).Engines == nil {
-				(*table).Engines = map[int32]*EngineCheckpointModel{}
+			if table.Engines == nil {
+				table.Engines = map[int32]*EngineCheckpointModel{}
 			}
-			for _, engine := range (*table).Engines {
-				if (*engine).Chunks == nil {
-					(*engine).Chunks = map[string]*ChunkCheckpointModel{}
+			for _, engine := range table.Engines {
+				if engine.Chunks == nil {
+					engine.Chunks = map[string]*ChunkCheckpointModel{}
 				}
 			}
 		}

--- a/lightning/checkpoints/checkpoints_test.go
+++ b/lightning/checkpoints/checkpoints_test.go
@@ -288,3 +288,17 @@ func (s *checkpointSuite) TestApplyDiff(c *C) {
 		},
 	})
 }
+
+func (s *checkpointSuite) TestCheckpointMarshallUnmarshall(c *C) {
+	path := "/tmp/test-chkp"
+	fileChkp := NewFileCheckpointsDB(path)
+	fileChkp.checkpoints.Checkpoints["a"] = &TableCheckpointModel{
+		Status:  uint32(CheckpointStatusLoaded),
+		Engines: map[int32]*EngineCheckpointModel{},
+	}
+	fileChkp.Close()
+
+	fileChkp2 := NewFileCheckpointsDB(path)
+	// if not recover empty map explicitly, it will become nil
+	c.Assert(fileChkp2.checkpoints.Checkpoints["a"].Engines, NotNil)
+}

--- a/lightning/checkpoints/checkpoints_test.go
+++ b/lightning/checkpoints/checkpoints_test.go
@@ -1,6 +1,7 @@
 package checkpoints
 
 import (
+	"path/filepath"
 	"testing"
 
 	. "github.com/pingcap/check"
@@ -290,7 +291,7 @@ func (s *checkpointSuite) TestApplyDiff(c *C) {
 }
 
 func (s *checkpointSuite) TestCheckpointMarshallUnmarshall(c *C) {
-	path := "/tmp/test-chkp"
+	path := filepath.Join(c.MkDir(), "filecheckpoint")
 	fileChkp := NewFileCheckpointsDB(path)
 	fileChkp.checkpoints.Checkpoints["a"] = &TableCheckpointModel{
 		Status:  uint32(CheckpointStatusLoaded),


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-Lightning! Please read the [CONTRIBUTING](https://github.com/pingcap/tidb-lightning/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
fix empty map become nil after marshall and unmarshall

### What is changed and how it works?
manually init these map. Seems it's a bug of marshall function provided by gogoproto.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test, add an unit test. If we didn't init these map after unmarshall this test won't pass(hope I didn't make it wrong)

Side effects

Related changes

 - Need to cherry-pick to the release branch