### PR TITLE
[3.0]checkpoint: fix empty map become nil after unmarshall (#237)

### DIFF
--- a/lightning/checkpoints/checkpoints_test.go
+++ b/lightning/checkpoints/checkpoints_test.go
@@ -1,6 +1,7 @@
 package checkpoints
 
 import (
+	"path/filepath"
 	"testing"
 
 	. "github.com/pingcap/check"
@@ -287,4 +288,18 @@ func (s *checkpointSuite) TestApplyDiff(c *C) {
 			},
 		},
 	})
+}
+
+func (s *checkpointSuite) TestCheckpointMarshallUnmarshall(c *C) {
+	path := filepath.Join(c.MkDir(), "filecheckpoint")
+	fileChkp := NewFileCheckpointsDB(path)
+	fileChkp.checkpoints.Checkpoints["a"] = &TableCheckpointModel{
+		Status:  uint32(CheckpointStatusLoaded),
+		Engines: map[int32]*EngineCheckpointModel{},
+	}
+	fileChkp.Close()
+
+	fileChkp2 := NewFileCheckpointsDB(path)
+	// if not recover empty map explicitly, it will become nil
+	c.Assert(fileChkp2.checkpoints.Checkpoints["a"].Engines, NotNil)
 }


### PR DESCRIPTION


<!--
Thank you for contributing to TiDB-Lightning! Please read the [CONTRIBUTING](https://github.com/pingcap/tidb-lightning/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
cherry-pick for #237 

* checkpoint: fix empty map become nil after unmarshall

* checkpoint: unify code style

* checkpoint: remove hard-coded path

### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Side effects

Related changes