### PR TITLE
config: increase default concurrency

### DIFF
--- a/lightning/config/config.go
+++ b/lightning/config/config.go
@@ -47,10 +47,6 @@ const (
 	CheckpointDriverMySQL = "mysql"
 	// CheckpointDriverFile is a constant for choosing the "File" checkpoint driver in the configuration.
 	CheckpointDriverFile = "file"
-
-	DefaultTableConcurrency = 6
-	DefaultIndexConcurrency = 2
-	DefaultIOConcurrency    = 5
 )
 
 var defaultConfigPaths = []string{"tidb-lightning.toml", "conf/tidb-lightning.toml"}
@@ -170,9 +166,9 @@ func NewConfig() *Config {
 	return &Config{
 		App: Lightning{
 			RegionConcurrency: runtime.NumCPU(),
-			TableConcurrency:  DefaultTableConcurrency,
-			IndexConcurrency:  DefaultIndexConcurrency,
-			IOConcurrency:     DefaultIOConcurrency,
+			TableConcurrency:  6,
+			IndexConcurrency:  2,
+			IOConcurrency:     5,
 			CheckRequirements: true,
 		},
 		TiDB: DBStore{

--- a/lightning/config/config.go
+++ b/lightning/config/config.go
@@ -47,6 +47,10 @@ const (
 	CheckpointDriverMySQL = "mysql"
 	// CheckpointDriverFile is a constant for choosing the "File" checkpoint driver in the configuration.
 	CheckpointDriverFile = "file"
+
+	DefaultTableConcurrency = 6
+	DefaultIndexConcurrency = 2
+	DefaultIOConcurrency    = 5
 )
 
 var defaultConfigPaths = []string{"tidb-lightning.toml", "conf/tidb-lightning.toml"}
@@ -166,9 +170,9 @@ func NewConfig() *Config {
 	return &Config{
 		App: Lightning{
 			RegionConcurrency: runtime.NumCPU(),
-			TableConcurrency:  6,
-			IndexConcurrency:  2,
-			IOConcurrency:     5,
+			TableConcurrency:  DefaultTableConcurrency,
+			IndexConcurrency:  DefaultIndexConcurrency,
+			IOConcurrency:     DefaultIOConcurrency,
 			CheckRequirements: true,
 		},
 		TiDB: DBStore{

--- a/lightning/config/config.go
+++ b/lightning/config/config.go
@@ -166,8 +166,8 @@ func NewConfig() *Config {
 	return &Config{
 		App: Lightning{
 			RegionConcurrency: runtime.NumCPU(),
-			TableConcurrency:  6,
-			IndexConcurrency:  2,
+			TableConcurrency:  0,
+			IndexConcurrency:  0,
 			IOConcurrency:     5,
 			CheckRequirements: true,
 		},
@@ -308,7 +308,20 @@ func (cfg *Config) Adjust() error {
 
 	cfg.TikvImporter.Backend = strings.ToLower(cfg.TikvImporter.Backend)
 	switch cfg.TikvImporter.Backend {
-	case BackendTiDB, BackendImporter:
+	case BackendTiDB:
+		if cfg.App.IndexConcurrency == 0 {
+			cfg.App.IndexConcurrency = cfg.App.RegionConcurrency
+		}
+		if cfg.App.TableConcurrency == 0 {
+			cfg.App.TableConcurrency = cfg.App.RegionConcurrency
+		}
+	case BackendImporter:
+		if cfg.App.IndexConcurrency == 0 {
+			cfg.App.IndexConcurrency = 2
+		}
+		if cfg.App.TableConcurrency == 0 {
+			cfg.App.TableConcurrency = 6
+		}
 	default:
 		return errors.Errorf("invalid config: unsupported `tikv-importer.backend` (%s)", cfg.TikvImporter.Backend)
 	}

--- a/lightning/restore/restore.go
+++ b/lightning/restore/restore.go
@@ -173,18 +173,6 @@ func NewRestoreController(ctx context.Context, dbMetas []*mydump.MDDatabaseMeta,
 		}
 	case config.BackendTiDB:
 		backend = kv.NewTiDBBackend(tidbMgr.db)
-		// in TiDBBackend, indexConcurrency and tableConcurrency has few effect but only limit regionConcurrency when
-		// table/engine has a few chunks. So we here increase two concurrency if user not specify.
-		tableNum := 0
-		for _, dbMeta := range dbMetas {
-			tableNum += len(dbMeta.Tables)
-		}
-		if cfg.App.IndexConcurrency == config.DefaultIndexConcurrency {
-			cfg.App.IndexConcurrency = tableNum
-		}
-		if cfg.App.TableConcurrency == config.DefaultTableConcurrency {
-			cfg.App.TableConcurrency = tableNum
-		}
 	default:
 		return nil, errors.New("unknown backend: " + cfg.TikvImporter.Backend)
 	}


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-Lightning! Please read the [CONTRIBUTING](https://github.com/pingcap/tidb-lightning/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
To reduce config of TiDB backend and user's effort, indexConcurrency and tableConcurrency may set to a large value automatically.

### What is changed and how it works?
Computing the sum of tables to be imported, set indexConcurrency and tableConcurrency to this sum in TiDB backend mode

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Side effects

Related changes