### PR TITLE
Fix +incompatible suffix not allowed error reported by go mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/pingcap/kvproto v0.0.0-20191011042334-8ee4fd8fb4ca
 	github.com/pingcap/log v0.0.0-20190307075452-bd41d9273596
 	github.com/pingcap/parser v0.0.0-20190910041007-2a177b291004
-	github.com/pingcap/tidb v3.0.4+incompatible
+	github.com/pingcap/tidb v1.1.0-beta.0.20190929123532-694e086e7914
 	github.com/pingcap/tidb-tools v3.0.4+incompatible
 	github.com/prometheus/client_golang v1.1.0
 	github.com/prometheus/client_model v0.0.0-20190129233127-fd36f4220a90

--- a/go.sum
+++ b/go.sum
@@ -199,8 +199,8 @@ github.com/pingcap/parser v0.0.0-20190910041007-2a177b291004 h1:LaA55frHvXh8vTYc
 github.com/pingcap/parser v0.0.0-20190910041007-2a177b291004/go.mod h1:1FNvfp9+J0wvc4kl8eGNh7Rqrxveg15jJoWo/a0uHwA=
 github.com/pingcap/pd v0.0.0-20190711034019-ee98bf9063e9 h1:sqqiviE8oEYXJh3Aq59HO/AhxjsvcRb9ETh0ivFOHXc=
 github.com/pingcap/pd v0.0.0-20190711034019-ee98bf9063e9/go.mod h1:3DlDlFT7EF64A1bmb/tulZb6wbPSagm5G4p1AlhaEDs=
-github.com/pingcap/tidb v3.0.4+incompatible h1:fqx8EY8o8zP7ikZByKDmWNONJ4ho3LxlCMak+kQEgBw=
-github.com/pingcap/tidb v3.0.4+incompatible/go.mod h1:+HaxcVzgm1Lq+8ccv1SbpZkXB9qq80dqqMqpBgF6VcI=
+github.com/pingcap/tidb v1.1.0-beta.0.20190929123532-694e086e7914 h1:YPvqo9dzPtFius86rCcEfWIfViDyEM/7LBh2Ers9LaU=
+github.com/pingcap/tidb v1.1.0-beta.0.20190929123532-694e086e7914/go.mod h1:+HaxcVzgm1Lq+8ccv1SbpZkXB9qq80dqqMqpBgF6VcI=
 github.com/pingcap/tidb-tools v2.1.3-0.20190321065848-1e8b48f5c168+incompatible/go.mod h1:XGdcy9+yqlDSEMTpOXnwf3hiTeqrV6MN/u1se9N8yIM=
 github.com/pingcap/tidb-tools v3.0.4+incompatible h1:pRrt3imAP/ggECId1veaDlTL7oFElY85pH/uuz76wnM=
 github.com/pingcap/tidb-tools v3.0.4+incompatible/go.mod h1:XGdcy9+yqlDSEMTpOXnwf3hiTeqrV6MN/u1se9N8yIM=

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -1,1 +1,5 @@
 // Exclude this directory from the Go module
+
+module github.com/pingcap/tidb-lightning/tests
+
+go 1.13

--- a/web/go.mod
+++ b/web/go.mod
@@ -1,1 +1,5 @@
 // Exclude this directory from the Go module
+
+module github.com/pingcap/tidb-lightning/web
+
+go 1.13


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-Lightning! Please read the [CONTRIBUTING](https://github.com/pingcap/tidb-lightning/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Fix +incompatible suffix not allowed error reported by go mod

### What is changed and how it works?

1. `go get -ugithub.com/pingcap/tidb@694e086e7`  (which is v3.0.4)
1. `go mod tidy`

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test
    Use `make lightning` to check if we can still build.
 - No code