### PR TITLE
Add password as command line argument

### DIFF
--- a/lightning/config/config.go
+++ b/lightning/config/config.go
@@ -222,6 +222,7 @@ func (cfg *Config) LoadFromGlobal(global *GlobalConfig) error {
 	cfg.TiDB.Host = global.TiDB.Host
 	cfg.TiDB.Port = global.TiDB.Port
 	cfg.TiDB.User = global.TiDB.User
+	cfg.TiDB.Psw  = global.TiDB.Psw
 	cfg.TiDB.StatusPort = global.TiDB.StatusPort
 	cfg.TiDB.PdAddr = global.TiDB.PdAddr
 	cfg.Mydumper.SourceDir = global.Mydumper.SourceDir

--- a/lightning/config/config_test.go
+++ b/lightning/config/config_test.go
@@ -369,7 +369,7 @@ func (s *configTestSuite) TestLoadConfig(c *C) {
 		"-tidb-host", "172.16.30.11",
 		"-tidb-port", "4001",
 		"-tidb-user", "guest",
-		"-tidb-pwd", "12345",
+		"-tidb-password", "12345",
 		"-pd-urls", "172.16.30.11:2379,172.16.30.12:2379",
 		"-d", "/path/to/import",
 		"-importer", "172.16.30.11:23008",

--- a/lightning/config/config_test.go
+++ b/lightning/config/config_test.go
@@ -369,6 +369,7 @@ func (s *configTestSuite) TestLoadConfig(c *C) {
 		"-tidb-host", "172.16.30.11",
 		"-tidb-port", "4001",
 		"-tidb-user", "guest",
+		"-tidb-pwd", "12345",
 		"-pd-urls", "172.16.30.11:2379,172.16.30.12:2379",
 		"-d", "/path/to/import",
 		"-importer", "172.16.30.11:23008",
@@ -379,6 +380,7 @@ func (s *configTestSuite) TestLoadConfig(c *C) {
 	c.Assert(cfg.TiDB.Host, Equals, "172.16.30.11")
 	c.Assert(cfg.TiDB.Port, Equals, 4001)
 	c.Assert(cfg.TiDB.User, Equals, "guest")
+	c.Assert(cfg.TiDB.Psw, Equals, "12345")
 	c.Assert(cfg.TiDB.PdAddr, Equals, "172.16.30.11:2379,172.16.30.12:2379")
 	c.Assert(cfg.Mydumper.SourceDir, Equals, "/path/to/import")
 	c.Assert(cfg.TikvImporter.Addr, Equals, "172.16.30.11:23008")
@@ -391,7 +393,7 @@ func (s *configTestSuite) TestLoadConfig(c *C) {
 	taskCfg.Checkpoint.Driver = config.CheckpointDriverMySQL
 	err = taskCfg.Adjust()
 	c.Assert(err, IsNil)
-	c.Assert(taskCfg.Checkpoint.DSN, Equals, "guest:@tcp(172.16.30.11:4001)/?charset=utf8&sql_mode='"+mysql.DefaultSQLMode+"'&maxAllowedPacket=67108864")
+	c.Assert(taskCfg.Checkpoint.DSN, Equals, "guest:12345@tcp(172.16.30.11:4001)/?charset=utf8&sql_mode='"+mysql.DefaultSQLMode+"'&maxAllowedPacket=67108864")
 
 	result := taskCfg.String()
 	c.Assert(result, Matches, `.*"pd-addr":"172.16.30.11:2379,172.16.30.12:2379".*`)

--- a/lightning/config/global.go
+++ b/lightning/config/global.go
@@ -112,7 +112,7 @@ func LoadGlobalConfig(args []string, extraFlags func(*flag.FlagSet)) (*GlobalCon
 	tidbHost := fs.String("tidb-host", "", "TiDB server host")
 	tidbPort := fs.Int("tidb-port", 0, "TiDB server port (default 4000)")
 	tidbUser := fs.String("tidb-user", "", "TiDB user name to connect")
-	tidbPsw  := fs.String("tidb-pwd", "", "TiDB password to connect")
+	tidbPsw  := fs.String("tidb-password", "", "TiDB password to connect")
 	tidbStatusPort := fs.Int("tidb-status", 0, "TiDB server status port (default 10080)")
 	pdAddr := fs.String("pd-urls", "", "PD endpoint address")
 	dataSrcPath := fs.String("d", "", "Directory of the dump to import")

--- a/lightning/config/global.go
+++ b/lightning/config/global.go
@@ -39,6 +39,7 @@ type GlobalTiDB struct {
 	Host       string `toml:"host" json:"host"`
 	Port       int    `toml:"port" json:"port"`
 	User       string `toml:"user" json:"user"`
+	Psw        string `toml:"password" json:"-"`
 	StatusPort int    `toml:"status-port" json:"status-port"`
 	PdAddr     string `toml:"pd-addr" json:"pd-addr"`
 	LogLevel   string `toml:"log-level" json:"log-level"`
@@ -111,6 +112,7 @@ func LoadGlobalConfig(args []string, extraFlags func(*flag.FlagSet)) (*GlobalCon
 	tidbHost := fs.String("tidb-host", "", "TiDB server host")
 	tidbPort := fs.Int("tidb-port", 0, "TiDB server port (default 4000)")
 	tidbUser := fs.String("tidb-user", "", "TiDB user name to connect")
+	tidbPsw  := fs.String("tidb-pwd", "", "TiDB password to connect")
 	tidbStatusPort := fs.Int("tidb-status", 0, "TiDB server status port (default 10080)")
 	pdAddr := fs.String("pd-urls", "", "PD endpoint address")
 	dataSrcPath := fs.String("d", "", "Directory of the dump to import")
@@ -160,6 +162,9 @@ func LoadGlobalConfig(args []string, extraFlags func(*flag.FlagSet)) (*GlobalCon
 	}
 	if *tidbUser != "" {
 		cfg.TiDB.User = *tidbUser
+	}
+	if *tidbPsw != "" {
+		cfg.TiDB.Psw = *tidbPsw
 	}
 	if *pdAddr != "" {
 		cfg.TiDB.PdAddr = *pdAddr


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-Lightning! Please read the [CONTRIBUTING](https://github.com/pingcap/tidb-lightning/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Previously it is not possible to supply the user password by command line, unlike other restore tools like `loader`


### What is changed and how it works?
Adds `-tidb-password` command line option


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Manual test (add detailed scripts or steps below)

Side effects

 - Possible performance regression
 - Increased code complexity
 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation
 - Need to update the `tidb-ansible` repository
 - Need to be included in the release note