### PR TITLE
Some SwitchMode improvements

### DIFF
--- a/lightning/backend/tikv.go
+++ b/lightning/backend/tikv.go
@@ -21,6 +21,8 @@ import (
 	"go.uber.org/zap"
 	"golang.org/x/sync/errgroup"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	"github.com/pingcap/tidb-lightning/lightning/common"
 	"github.com/pingcap/tidb-lightning/lightning/log"
@@ -124,14 +126,22 @@ func ForAllStores(
 	return eg.Wait()
 }
 
+func ignoreUnimplementedError(err error, logger log.Logger) error {
+	if status.Code(err) == codes.Unimplemented {
+		logger.Debug("skipping potentially TiFlash store")
+		return nil
+	}
+	return errors.Trace(err)
+}
+
 // SwitchMode changes the TiKV node at the given address to a particular mode.
 func SwitchMode(ctx context.Context, tls *common.TLS, tikvAddr string, mode import_sstpb.SwitchMode) error {
-	task := log.With(zap.Stringer("mode", mode)).Begin(zap.DebugLevel, "switch mode")
+	task := log.With(zap.Stringer("mode", mode), zap.String("tikv", tikvAddr)).Begin(zap.DebugLevel, "switch mode")
 	err := withTiKVConnection(ctx, tls, tikvAddr, func(client import_sstpb.ImportSSTClient) error {
 		_, err := client.SwitchMode(ctx, &import_sstpb.SwitchModeRequest{
 			Mode: mode,
 		})
-		return errors.Trace(err)
+		return ignoreUnimplementedError(err, task.Logger)
 	})
 	task.End(zap.WarnLevel, err)
 	return err
@@ -139,12 +149,12 @@ func SwitchMode(ctx context.Context, tls *common.TLS, tikvAddr string, mode impo
 
 // Compact performs a leveled compaction with the given minimum level.
 func Compact(ctx context.Context, tls *common.TLS, tikvAddr string, level int32) error {
-	task := log.With(zap.Int32("level", level)).Begin(zap.InfoLevel, "compact cluster")
+	task := log.With(zap.Int32("level", level), zap.String("tikv", tikvAddr)).Begin(zap.InfoLevel, "compact cluster")
 	err := withTiKVConnection(ctx, tls, tikvAddr, func(client import_sstpb.ImportSSTClient) error {
 		_, err := client.Compact(ctx, &import_sstpb.CompactRequest{
 			OutputLevel: level,
 		})
-		return errors.Trace(err)
+		return ignoreUnimplementedError(err, task.Logger)
 	})
 	task.End(zap.ErrorLevel, err)
 	return err


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-Lightning! Please read the [CONTRIBUTING](https://github.com/pingcap/tidb-lightning/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Fix #134 and AskTUG-33070.

### What is changed and how it works?

1. During switch mode, if we encounter a store that returns Unimplemented (mainly TiFlash nowadays), simply ignore the error.
2. Added `./tidb-lightning-ctl --fetch-mode` subcommand to print the mode.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Manual test (add detailed scripts or steps below)

Side effects

Related changes

 - Need to update the documentation
 - Need to be included in the release note
    * Document the new `--fetch-mode` flag.