### PR TITLE
Support store version format generated by `git describe --tags`

### DIFF
--- a/lightning/restore/checkreq_test.go
+++ b/lightning/restore/checkreq_test.go
@@ -180,6 +180,9 @@ func (s *checkReqSuite) TestCheckTiKVVersion(c *C) {
 	versions = []string{"9999.0.0", "9999.0.0"}
 	c.Assert(rc.checkTiKVVersion(), IsNil)
 
+	versions = []string{"4.1.0", "v4.1.0-alpha-9-ga27a7dd"}
+	c.Assert(rc.checkTiKVVersion(), IsNil)
+
 	versions = []string{"9999.0.0", "1.0.0"}
 	c.Assert(rc.checkTiKVVersion(), ErrorMatches, `TiKV \(at tikv1\.test:20160\) version too old.*`)
 }

--- a/lightning/restore/restore.go
+++ b/lightning/restore/restore.go
@@ -1207,7 +1207,7 @@ func (rc *RestoreController) checkTiKVVersion() error {
 		kv.StoreStateDown,
 		func(c context.Context, store *kv.Store) error {
 			component := fmt.Sprintf("TiKV (at %s)", store.Address)
-			version, err := semver.NewVersion(store.Version)
+			version, err := semver.NewVersion(strings.TrimPrefix(store.Version, "v"))
 			if err != nil {
 				return errors.Annotate(err, component)
 			}


### PR DESCRIPTION
Signed-off-by: Tong Zhigao <tongzhigao@pingcap.com>

### What problem does this PR solve? <!--add issue link with summary if exists-->

- Support store version format generated by `git describe --tags`, like `v4.1.0-alpha-9-ga27a7dd`.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual
