### PR TITLE
skip version check when pd-addr is not given

### DIFF
--- a/lightning/restore/restore.go
+++ b/lightning/restore/restore.go
@@ -1132,6 +1132,10 @@ func (rc *RestoreController) checkRequirements(_ context.Context) error {
 	// skip requirement check if explicitly turned off
 	if !rc.cfg.App.CheckRequirements {
 		return nil
+	} else if rc.cfg.TiDB.PdAddr == "" {
+		log.L().Warn("pd address is not given, lightning will skip tidb/pd/tikv version check")
+		fmt.Fprintf(os.Stdout, "pd address is not given, lightning will skip tidb/pd/tikv version check.\n\n")
+		return nil
 	}
 
 	if err := rc.checkTiDBVersion(); err != nil {


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-Lightning! Please read the [CONTRIBUTING](https://github.com/pingcap/tidb-lightning/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
https://github.com/pingcap/tidb-lightning/issues/306
Sometimes user doesn't give pd-addr but the default `CheckRequirements` is true and version check will fail.

### What is changed and how it works?
Skip version check but warn users when pd-addr is not give but `CheckRequirements` is true.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
