### PR TITLE
Warn for single large file, change switch mode log level to info

### DIFF
--- a/lightning/backend/tikv.go
+++ b/lightning/backend/tikv.go
@@ -145,7 +145,7 @@ func SwitchMode(ctx context.Context, tls *common.TLS, tikvAddr string, mode impo
 		})
 		return ignoreUnimplementedError(err, task.Logger)
 	})
-	task.End(zap.WarnLevel, err)
+	task.End(zap.InfoLevel, err)
 	return err
 }
 

--- a/lightning/mydump/region.go
+++ b/lightning/mydump/region.go
@@ -190,8 +190,10 @@ func MakeTableRegions(
 		}
 		filesRegions = append(filesRegions, tableRegion)
 		if tableRegion.Size() > tableRegionSizeWarningThreshold {
-			log.L().Warn("single sql file's size exceeds 1G, please modify dump configs to split file" +
-				" in several smaller files to improve lightning's efficiency", zap.String("file", dataFile))
+			log.L().Warn(
+				"file is too big to be processed efficiently; we suggest splitting it at 256 MB each",
+				zap.String("file", dataFile),
+				zap.Int64("size", dataFileSize))
 		}
 		prevRowIDMax = rowIDMax
 		dataFileSizes = append(dataFileSizes, float64(dataFileSize))

--- a/lightning/mydump/region.go
+++ b/lightning/mydump/region.go
@@ -19,9 +19,14 @@ import (
 	"strings"
 
 	"github.com/pingcap/errors"
+	"go.uber.org/zap"
+
 	"github.com/pingcap/tidb-lightning/lightning/config"
+	"github.com/pingcap/tidb-lightning/lightning/log"
 	"github.com/pingcap/tidb-lightning/lightning/worker"
 )
+
+const tableRegionSizeWarningThreshold int64 = 1024 * 1024 * 1024
 
 type TableRegion struct {
 	EngineID int32
@@ -172,7 +177,7 @@ func MakeTableRegions(
 			continue
 		}
 		rowIDMax := prevRowIDMax + dataFileSize/divisor
-		filesRegions = append(filesRegions, &TableRegion{
+		tableRegion := &TableRegion{
 			DB:    meta.DB,
 			Table: meta.Name,
 			File:  dataFile,
@@ -182,7 +187,12 @@ func MakeTableRegions(
 				PrevRowIDMax: prevRowIDMax,
 				RowIDMax:     rowIDMax,
 			},
-		})
+		}
+		filesRegions = append(filesRegions, tableRegion)
+		if tableRegion.Size() > tableRegionSizeWarningThreshold {
+			log.L().Warn("single sql file's size exceeds 1G, please modify dump configs to split file" +
+				" in several smaller files to improve lightning's efficiency", zap.String("file", dataFile))
+		}
 		prevRowIDMax = rowIDMax
 		dataFileSizes = append(dataFileSizes, float64(dataFileSize))
 	}


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-Lightning! Please read the [CONTRIBUTING](https://github.com/pingcap/tidb-lightning/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
https://github.com/pingcap/tidb-lightning/issues/309
Warn users when single table region size exceeds 1G.

### What is changed and how it works?
Add warning log.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test