### PR TITLE
lightning: fix web page not showing when not using server mode

### DIFF
--- a/lightning/lightning.go
+++ b/lightning/lightning.go
@@ -293,6 +293,8 @@ func (l *Lightning) handleGetTask(w http.ResponseWriter) {
 
 	if l.taskCfgs != nil {
 		response.QueuedIDs = l.taskCfgs.AllIDs()
+	} else {
+		response.QueuedIDs = []int64{}
 	}
 
 	l.cancelLock.Lock()


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-Lightning! Please read the [CONTRIBUTING](https://github.com/pingcap/tidb-lightning/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Fix #231. 

### What is changed and how it works?

Go serializes a nil slice into `null` rather than `[]`, which JavaScript will distinguish. 

Explicitly initialize the empty slice as `[]int64{}` to avoid this.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)
    * Run lightning outside the server mode and check the web page.

Side effects

Related changes

