### PR TITLE
add log for environment http proxy setting

### DIFF
--- a/lightning/lightning.go
+++ b/lightning/lightning.go
@@ -238,9 +238,7 @@ func logEnvVariables() {
 	// log http proxy settings, it will be used in gRPC connection by default
 	proxyCfg := httpproxy.FromEnvironment()
 	if proxyCfg.HTTPProxy != "" || proxyCfg.HTTPSProxy != "" {
-		common.PrintInfo("lightning", func() {
-			log.L().Info("environment variables", zap.Reflect("httpproxy", proxyCfg))
-		})
+		log.L().Info("environment variables", zap.Reflect("httpproxy", proxyCfg))
 	}
 }
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-Lightning! Please read the [CONTRIBUTING](https://github.com/pingcap/tidb-lightning/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Add log for environment httpproxy settings

### What is changed and how it works?
The default [connection dialer](https://github.com/grpc/grpc-go/blob/v1.26.x/clientconn.go#L200) will use the  httpproxy setting from environment variables (see [`httpproxy.FromEnvironment()`](https://github.com/golang/net/blob/master/http/httpproxy/proxy.go#L91-L98)) to setup connections. So log these environment variables can make it easier in trouble shooting.

Example log:
```
[2020/06/29 16:09:53.401 +08:00] [INFO] [lightning.go:242] ["environment variables"] [httpproxy="{\"HTTPProxy\":\"127.0.0.1:1080\",\"HTTPSProxy\":\"\",\"NoProxy\":\"\",\"CGI\":false}"]
```

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

Side effects

 - Possible performance regression
 - Increased code complexity
 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation
 - Need to update the `tidb-ansible` repository
 - Need to be included in the release note