### PR TITLE
server: check open file ulimit for local backend

### DIFF
--- a/cmd/tidb-lightning/main.go
+++ b/cmd/tidb-lightning/main.go
@@ -17,8 +17,11 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
+	"path/filepath"
 	"runtime/debug"
 	"syscall"
+
+	"github.com/pingcap/errors"
 
 	"github.com/pingcap/tidb-lightning/lightning"
 	"github.com/pingcap/tidb-lightning/lightning/config"
@@ -29,6 +32,12 @@ import (
 func main() {
 	cfg := config.Must(config.LoadGlobalConfig(os.Args[1:], nil))
 	fmt.Fprintf(os.Stdout, "Verbose debug logs will be written to %s.\n\n", cfg.App.Config.File)
+	err := checkSystemRequirement(cfg)
+	if err != nil {
+		log.L().Error("check system requirements failed", zap.Error(err))
+		fmt.Fprintln(os.Stderr, "check system requirements failed:", err)
+		return
+	}
 
 	app := lightning.New(cfg)
 
@@ -66,7 +75,7 @@ func main() {
 		}
 	}
 
-	err := app.GoServe()
+	err = app.GoServe()
 	if err != nil {
 		logger.Error("failed to start HTTP server", zap.Error(err))
 		fmt.Fprintln(os.Stderr, "failed to start HTTP server:", err)
@@ -95,4 +104,48 @@ func main() {
 	if err != nil {
 		os.Exit(1)
 	}
+}
+
+func checkSystemRequirement(cfg *config.GlobalConfig) error {
+	if cfg.TikvImporter.Backend == config.BackendLocal {
+		// in local mode, we need to read&write a lot of L0 sst files, so we need to check
+		// system max open files limit
+		var totalSize uint64
+		err := filepath.Walk(cfg.Mydumper.SourceDir, func(path string, info os.FileInfo, err error) error {
+			if err != nil {
+				return err
+			}
+			if !info.IsDir() && info.Size() > 0 {
+				totalSize += uint64(info.Size())
+			}
+			return err
+		})
+		if err != nil {
+			return errors.Trace(err)
+		}
+
+		// we estimate each sst as 50MB, this is a fairly coarse predict, the actual fd needed is
+		// depend on chunk&import concurrency and each data&index key-value size
+		estimateMaxFiles := totalSize / (50 * 1024 * 1024)
+		var rLimit syscall.Rlimit
+		err = syscall.Getrlimit(syscall.RLIMIT_NOFILE, &rLimit)
+		if err != nil {
+			return errors.Trace(err)
+		}
+		if rLimit.Cur >= estimateMaxFiles {
+			return nil
+		}
+		if rLimit.Max < estimateMaxFiles {
+			// If the process is not started by privileged user, this will fail.
+			rLimit.Max = estimateMaxFiles
+		}
+		prevLimit := rLimit.Cur
+		rLimit.Cur = estimateMaxFiles
+		err = syscall.Setrlimit(syscall.RLIMIT_NOFILE, &rLimit)
+		if err != nil {
+			return errors.Wrap(err, fmt.Sprintf("the maximum number of open file descriptors is too small, got %d, expect greater or equal to %d", prevLimit, estimateMaxFiles))
+		}
+	}
+
+	return nil
 }

--- a/lightning/backend/local.go
+++ b/lightning/backend/local.go
@@ -62,6 +62,8 @@ const (
 	gRPCKeepAliveTime    = 10 * time.Second
 	gRPCKeepAliveTimeout = 3 * time.Second
 	gRPCBackOffMaxDelay  = 3 * time.Second
+
+	LocalMemoryTableSize = 512 << 20
 )
 
 var (
@@ -257,7 +259,7 @@ func (local *local) ShouldPostProcess() bool {
 
 func (local *local) openEngineDB(engineUUID uuid.UUID, readOnly bool) (*pebble.DB, error) {
 	opt := &pebble.Options{
-		MemTableSize:             512 << 20,
+		MemTableSize:             LocalMemoryTableSize,
 		MaxConcurrentCompactions: 16,
 		MinCompactionRate:        1 << 30,
 		L0CompactionThreshold:    math.MaxInt32, // set to max try to disable compaction

--- a/lightning/lightning.go
+++ b/lightning/lightning.go
@@ -177,19 +177,6 @@ func (l *Lightning) run(taskCfg *config.Config) (err error) {
 		log.L().Info("cfg", zap.Stringer("cfg", taskCfg))
 	})
 
-	loadTask := log.L().Begin(zap.InfoLevel, "load data source")
-	var mdl *mydump.MDLoader
-	mdl, err = mydump.NewMyDumpLoader(taskCfg)
-	loadTask.End(zap.ErrorLevel, err)
-	if err != nil {
-		return errors.Trace(err)
-	}
-	err = checkSystemRequirement(taskCfg, mdl.GetDatabases())
-	if err != nil {
-		log.L().Error("check system requirements failed", zap.Error(err))
-		return errors.Trace(err)
-	}
-
 	ctx, cancel := context.WithCancel(l.ctx)
 	l.cancelLock.Lock()
 	l.cancel = cancel
@@ -216,6 +203,18 @@ func (l *Lightning) run(taskCfg *config.Config) (err error) {
 		return nil
 	})
 
+	loadTask := log.L().Begin(zap.InfoLevel, "load data source")
+	var mdl *mydump.MDLoader
+	mdl, err = mydump.NewMyDumpLoader(taskCfg)
+	loadTask.End(zap.ErrorLevel, err)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	err = checkSystemRequirement(taskCfg, mdl.GetDatabases())
+	if err != nil {
+		log.L().Error("check system requirements failed", zap.Error(err))
+		return errors.Trace(err)
+	}
 	dbMetas := mdl.GetDatabases()
 	web.BroadcastInitProgress(dbMetas)
 

--- a/lightning/lightning_test.go
+++ b/lightning/lightning_test.go
@@ -22,6 +22,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/pingcap/tidb-lightning/lightning/mydump"
+
 	. "github.com/pingcap/check"
 	"github.com/pingcap/failpoint"
 	"github.com/pingcap/tidb-lightning/lightning/config"
@@ -398,4 +400,64 @@ func (s *lightningServerSuite) TestHTTPAPIOutsideServerMode(c *C) {
 
 	// ... and the task should be canceled now.
 	c.Assert(<-errCh, Equals, context.Canceled)
+}
+
+func (s *lightningServerSuite) TestCheckSystemRequirement(c *C) {
+	cfg := config.NewConfig()
+	cfg.App.TableConcurrency = 4
+	cfg.TikvImporter.Backend = config.BackendLocal
+
+	dbMetas := []*mydump.MDDatabaseMeta{
+		{
+			Tables: []*mydump.MDTableMeta{
+				{
+					TotalSize: 500 << 20, //500MB
+				},
+				{
+					TotalSize: 150_000 << 20, //200_000MB
+				},
+			},
+		},
+		{
+			Tables: []*mydump.MDTableMeta{
+				{
+					TotalSize: 150_800 << 20, //150_288MB
+				},
+				{
+					TotalSize: 35 << 20, //35MB
+				},
+				{
+					TotalSize: 100_000 << 20, //150_288MB
+				},
+			},
+		},
+		{
+			Tables: []*mydump.MDTableMeta{
+				{
+					TotalSize: 240 << 20, //500000MB
+				},
+				{
+					TotalSize: 124_000 << 20, //500000MB
+				},
+			},
+		},
+	}
+
+	// with max open files 1024, the max table size will be: 524288MB
+	err := failpoint.Enable("github.com/pingcap/tidb-lightning/lightning/GetRlimitValue", "return(1024)")
+	c.Assert(err, IsNil)
+	err = failpoint.Enable("github.com/pingcap/tidb-lightning/lightning/SetRlimitError", "return(true)")
+	c.Assert(err, IsNil)
+	defer failpoint.Disable("github.com/pingcap/tidb-lightning/lightning/SetRlimitError")
+	// with this dbMetas, the estimated fds will be 1025, so should return error
+	err = checkSystemRequirement(cfg, dbMetas)
+	c.Assert(err, NotNil)
+	err = failpoint.Disable("github.com/pingcap/tidb-lightning/lightning/GetRlimitValue")
+	c.Assert(err, IsNil)
+
+	err = failpoint.Enable("github.com/pingcap/tidb-lightning/lightning/GetRlimitValue", "return(1025)")
+	defer failpoint.Disable("github.com/pingcap/tidb-lightning/lightning/GetRlimitValue")
+	c.Assert(err, IsNil)
+	err = checkSystemRequirement(cfg, dbMetas)
+	c.Assert(err, IsNil)
 }

--- a/lightning/lightning_test.go
+++ b/lightning/lightning_test.go
@@ -411,23 +411,23 @@ func (s *lightningServerSuite) TestCheckSystemRequirement(c *C) {
 		{
 			Tables: []*mydump.MDTableMeta{
 				{
-					TotalSize: 500 << 20, //500MB
+					TotalSize: 500 << 20,
 				},
 				{
-					TotalSize: 150_000 << 20, //200_000MB
+					TotalSize: 150_000 << 20,
 				},
 			},
 		},
 		{
 			Tables: []*mydump.MDTableMeta{
 				{
-					TotalSize: 150_800 << 20, //150_288MB
+					TotalSize: 150_800 << 20,
 				},
 				{
-					TotalSize: 35 << 20, //35MB
+					TotalSize: 35 << 20,
 				},
 				{
-					TotalSize: 100_000 << 20, //150_288MB
+					TotalSize: 100_000 << 20,
 				},
 			},
 		},

--- a/lightning/lightning_test.go
+++ b/lightning/lightning_test.go
@@ -434,10 +434,10 @@ func (s *lightningServerSuite) TestCheckSystemRequirement(c *C) {
 		{
 			Tables: []*mydump.MDTableMeta{
 				{
-					TotalSize: 240 << 20, //500000MB
+					TotalSize: 240 << 20,
 				},
 				{
-					TotalSize: 124_000 << 20, //500000MB
+					TotalSize: 124_000 << 20,
 				},
 			},
 		},


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-Lightning! Please read the [CONTRIBUTING](https://github.com/pingcap/tidb-lightning/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Check process max open file limit for local backend

### What is changed and how it works?
In local backend mode, pebble need to write a lot of L0 sst files. So If data source is fairly big, the max_open_file limit may not be enough. So we check the `RLIMIT_NOFILE` base on source file size, and try to update it if not big enough.

close #342 

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

Side effects

Related changes
