### PR TITLE
log: fix log file path

### DIFF
--- a/cmd/tidb-lightning/main.go
+++ b/cmd/tidb-lightning/main.go
@@ -87,9 +87,12 @@ func main() {
 		fmt.Fprintln(os.Stdout, "tidb lightning exit")
 	}
 
-	syncErr := logger.Sync()
-	if syncErr != nil {
-		fmt.Fprintln(os.Stderr, "sync log failed", syncErr)
+	// call Sync() with log to stdout may return error in some case, so just skip it
+	if cfg.App.File != "" {
+		syncErr := logger.Sync()
+		if syncErr != nil {
+			fmt.Fprintln(os.Stderr, "sync log failed", syncErr)
+		}
 	}
 
 	if err != nil {

--- a/lightning/config/global.go
+++ b/lightning/config/global.go
@@ -197,7 +197,10 @@ func LoadGlobalConfig(args []string, extraFlags func(*flag.FlagSet)) (*GlobalCon
 	if *logFilePath != "" {
 		cfg.App.Config.File = *logFilePath
 	}
-	if cfg.App.Config.File == "" {
+	// "-" is a special config for log to stdout
+	if cfg.App.Config.File == "-" {
+		cfg.App.Config.File = ""
+	} else if cfg.App.Config.File == "" {
 		cfg.App.Config.File = timestampLogFileName()
 	}
 	if *tidbHost != "" {

--- a/lightning/config/global.go
+++ b/lightning/config/global.go
@@ -142,7 +142,7 @@ func LoadGlobalConfig(args []string, extraFlags func(*flag.FlagSet)) (*GlobalCon
 	printVersion := fs.Bool("V", false, "print version of lightning")
 
 	logLevel := flagext.ChoiceVar(fs, "L", "", `log level: info, debug, warn, error, fatal (default info)`, "", "info", "debug", "warn", "warning", "error", "fatal")
-	logFilePath := fs.String("log-file", timestampLogFileName(), "log file path")
+	logFilePath := fs.String("log-file", "", "log file path")
 	tidbHost := fs.String("tidb-host", "", "TiDB server host")
 	tidbPort := fs.Int("tidb-port", 0, "TiDB server port (default 4000)")
 	tidbUser := fs.String("tidb-user", "", "TiDB user name to connect")
@@ -196,6 +196,9 @@ func LoadGlobalConfig(args []string, extraFlags func(*flag.FlagSet)) (*GlobalCon
 	}
 	if *logFilePath != "" {
 		cfg.App.Config.File = *logFilePath
+	}
+	if cfg.App.Config.File == "" {
+		cfg.App.Config.File = timestampLogFileName()
 	}
 	if *tidbHost != "" {
 		cfg.TiDB.Host = *tidbHost

--- a/lightning/log/log.go
+++ b/lightning/log/log.go
@@ -77,16 +77,18 @@ var (
 func InitLogger(cfg *Config, tidbLoglevel string) error {
 	logutil.InitLogger(&logutil.LogConfig{Config: pclog.Config{Level: tidbLoglevel}})
 
-	logger, props, err := pclog.InitLogger(&pclog.Config{
+	logCfg := &pclog.Config{
 		Level: cfg.Level,
-		File: pclog.FileLogConfig{
+	}
+	if len(cfg.File) > 0 {
+		logCfg.File = pclog.FileLogConfig{
 			Filename:   cfg.File,
 			MaxSize:    cfg.FileMaxSize,
 			MaxDays:    cfg.FileMaxDays,
 			MaxBackups: cfg.FileMaxBackups,
-		},
-	})
-
+		}
+	}
+	logger, props, err := pclog.InitLogger(logCfg)
 	if err != nil {
 		return err
 	}

--- a/tidb-lightning.toml
+++ b/tidb-lightning.toml
@@ -35,6 +35,8 @@ table-concurrency = 6
 
 # logging
 level = "info"
+# file path for log. If set to empty, log will be written to /tmp/lightning.log.{timestamp}
+# Set to "-" to write logs to stdout.
 file = "tidb-lightning.log"
 max-size = 128 # MB
 max-days = 28


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-Lightning! Please read the [CONTRIBUTING](https://github.com/pingcap/tidb-lightning/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
fix lightning always set log file path to the default path

### What is changed and how it works?
Only set log path to default path if neither command line params nor config file set it 


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

Side effects

Related changes