### PR TITLE
backend: fix local backend may divide by 0

### DIFF
--- a/lightning/backend/local.go
+++ b/lightning/backend/local.go
@@ -547,7 +547,7 @@ func (local *local) ReadAndSplitIntoRange(engineFile *LocalFile, engineUUID uuid
 	log.L().Info("ReadAndSplitIntoRange", zap.Binary("start", startKey), zap.Binary("end", endKey))
 
 	// split data into n ranges, then seek n times to get n + 1 ranges
-	n := engineFile.TotalSize / local.regionSplitSize
+	n := (engineFile.TotalSize + local.regionSplitSize - 1) / local.regionSplitSize
 
 	ranges := make([]Range, 0, n+1)
 	if tablecodec.IsIndexKey(startKey) {
@@ -564,6 +564,9 @@ func (local *local) ReadAndSplitIntoRange(engineFile *LocalFile, engineUUID uuid
 
 		// each index has to split into n / indexCount ranges
 		indexRangeCount := n / indexCount
+		if indexRangeCount == 0 {
+			indexRangeCount = 1
+		}
 
 		for i := startIndexID; i <= endIndexID; i++ {
 			k := tablecodec.EncodeTableIndexPrefix(tableID, i)


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-Lightning! Please read the [CONTRIBUTING](https://github.com/pingcap/tidb-lightning/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
fix a divide by 0 bug in local backend when split index engine ranges

### What is changed and how it works?
If the index engine total size is bigger than RegionSplitSize but small than indexCount * RegionSplitSize, thus each index range count will be 0, thus split kv-pairs by range will encounter divide by 0 panic.


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

Side effects

Related changes
