### PR TITLE
restore: do not rebase auto-id or generate auto row id for table with common handle

### DIFF
--- a/lightning/backend/sql2kv.go
+++ b/lightning/backend/sql2kv.go
@@ -210,7 +210,7 @@ func (kvcodec *tableKVEncoder) Encode(
 		}
 	}
 
-	if !kvcodec.tbl.Meta().PKIsHandle {
+	if !kvcodec.tbl.Meta().PKIsHandle && !kvcodec.tbl.Meta().IsCommonHandle {
 		j := columnPermutation[len(cols)]
 		if j >= 0 && j < len(row) {
 			value, err = table.CastValue(kvcodec.se, row[j], extraHandleColumnInfo, false, false)

--- a/lightning/backend/sql2kv.go
+++ b/lightning/backend/sql2kv.go
@@ -210,7 +210,7 @@ func (kvcodec *tableKVEncoder) Encode(
 		}
 	}
 
-	if !kvcodec.tbl.Meta().PKIsHandle && !kvcodec.tbl.Meta().IsCommonHandle {
+	if common.TableHasAutoRowID(kvcodec.tbl.Meta()) {
 		j := columnPermutation[len(cols)]
 		if j >= 0 && j < len(row) {
 			value, err = table.CastValue(kvcodec.se, row[j], extraHandleColumnInfo, false, false)

--- a/lightning/common/util.go
+++ b/lightning/common/util.go
@@ -33,6 +33,7 @@ import (
 
 	"github.com/go-sql-driver/mysql"
 	"github.com/pingcap/errors"
+	"github.com/pingcap/parser/model"
 	tmysql "github.com/pingcap/tidb/errno"
 	"go.uber.org/zap"
 	"google.golang.org/grpc/codes"
@@ -310,4 +311,9 @@ type KvPair struct {
 	Key []byte
 	// Val is the value of the KV pair
 	Val []byte
+}
+
+// TableHasAutoRowID return whether table has auto generated row id
+func TableHasAutoRowID(info *model.TableInfo) bool {
+	return !info.PKIsHandle && !info.IsCommonHandle
 }

--- a/lightning/restore/restore.go
+++ b/lightning/restore/restore.go
@@ -1368,7 +1368,7 @@ func (t *TableRestore) populateChunks(rc *RestoreController, cp *TableCheckpoint
 // The argument `columns` _must_ be in lower case.
 func (t *TableRestore) initializeColumns(columns []string, ccp *ChunkCheckpoint) {
 	colPerm := make([]int, 0, len(t.tableInfo.Core.Columns)+1)
-	shouldIncludeRowID := !t.tableInfo.Core.PKIsHandle
+	shouldIncludeRowID := !t.tableInfo.Core.PKIsHandle && !t.tableInfo.Core.IsCommonHandle
 
 	if len(columns) == 0 {
 		// no provided columns, so use identity permutation.

--- a/lightning/restore/restore.go
+++ b/lightning/restore/restore.go
@@ -1087,7 +1087,7 @@ func (t *TableRestore) postProcess(ctx context.Context, rc *RestoreController, c
 		var err error
 		if tblInfo.PKIsHandle && tblInfo.ContainsAutoRandomBits() {
 			err = AlterAutoRandom(ctx, rc.tidbMgr.db, t.tableName, t.alloc.Get(autoid.AutoRandomType).Base()+1)
-		} else if (!tblInfo.PKIsHandle && !tblInfo.IsCommonHandle) || tblInfo.GetAutoIncrementColInfo() != nil {
+		} else if (common.TableHasAutoRowID(tblInfo)) || tblInfo.GetAutoIncrementColInfo() != nil {
 			// only alter auto increment id iff table contains auto-increment column or generated handle
 			err = AlterAutoIncrement(ctx, rc.tidbMgr.db, t.tableName, t.alloc.Get(autoid.RowIDAllocType).Base()+1)
 		}
@@ -1368,7 +1368,7 @@ func (t *TableRestore) populateChunks(rc *RestoreController, cp *TableCheckpoint
 // The argument `columns` _must_ be in lower case.
 func (t *TableRestore) initializeColumns(columns []string, ccp *ChunkCheckpoint) {
 	colPerm := make([]int, 0, len(t.tableInfo.Core.Columns)+1)
-	shouldIncludeRowID := !t.tableInfo.Core.PKIsHandle && !t.tableInfo.Core.IsCommonHandle
+	shouldIncludeRowID := common.TableHasAutoRowID(t.tableInfo.Core)
 
 	if len(columns) == 0 {
 		// no provided columns, so use identity permutation.

--- a/lightning/restore/restore.go
+++ b/lightning/restore/restore.go
@@ -1087,7 +1087,7 @@ func (t *TableRestore) postProcess(ctx context.Context, rc *RestoreController, c
 		var err error
 		if tblInfo.PKIsHandle && tblInfo.ContainsAutoRandomBits() {
 			err = AlterAutoRandom(ctx, rc.tidbMgr.db, t.tableName, t.alloc.Get(autoid.AutoRandomType).Base()+1)
-		} else if (common.TableHasAutoRowID(tblInfo)) || tblInfo.GetAutoIncrementColInfo() != nil {
+		} else if common.TableHasAutoRowID(tblInfo) || tblInfo.GetAutoIncrementColInfo() != nil {
 			// only alter auto increment id iff table contains auto-increment column or generated handle
 			err = AlterAutoIncrement(ctx, rc.tidbMgr.db, t.tableName, t.alloc.Get(autoid.RowIDAllocType).Base()+1)
 		}


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-Lightning! Please read the [CONTRIBUTING](https://github.com/pingcap/tidb-lightning/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Do not rebase auto-id or generate row id column for table with common handle

### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

Side effects


Related changes
