### PR TITLE
Fix verbose log message for shell

### DIFF
--- a/cmd/tidb-lightning/main.go
+++ b/cmd/tidb-lightning/main.go
@@ -28,7 +28,7 @@ import (
 
 func main() {
 	cfg := config.Must(config.LoadGlobalConfig(os.Args[1:], nil))
-	fmt.Fprintf(os.Stdout, "Verbose debug logs will be written to %s.\n\n", cfg.App.Config.File)
+	fmt.Fprintf(os.Stdout, "Verbose debug logs will be written to %s\n\n", cfg.App.Config.File)
 
 	app := lightning.New(cfg)
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-Lightning! Please read the [CONTRIBUTING](https://github.com/pingcap/tidb-lightning/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

When I run a new tidb-lightning task interactively, it generates a log file for verbose output. In my shell I double-click to pickup that file so I can copy it. Unfortunately it has a trailing `.` which is annoying enough to me that you are seeing this PR :-)

### What is changed and how it works?

Message text change

### Check List <!--REMOVE the items that are not applicable-->

 - No code

Side effects

 - None

Related changes

 - None
