### PR TITLE
restore: fix missing colum infos when restore from checkpoint

### DIFF
--- a/lightning/checkpoints/checkpoints.go
+++ b/lightning/checkpoints/checkpoints.go
@@ -913,11 +913,7 @@ func (cpdb *FileCheckpointsDB) InsertEngineCheckpoints(_ context.Context, tableN
 			chunk.RowidMax = value.Chunk.RowIDMax
 			chunk.Timestamp = value.Timestamp
 			if len(value.ColumnPermutation) > 0 {
-				permutation := make([]int32, len(value.ColumnPermutation))
-				for _, p := range value.ColumnPermutation {
-					permutation = append(permutation, int32(p))
-				}
-				chunk.ColumnPermutation = permutation
+				chunk.ColumnPermutation = intSlice2Int32Slice(value.ColumnPermutation)
 			}
 
 		}
@@ -1318,14 +1314,6 @@ func intSlice2Int32Slice(s []int) []int32 {
 	res := make([]int32, len(s))
 	for _, i := range s {
 		res = append(res, int32(i))
-	}
-	return res
-}
-
-func int32Slice2IntSlice(s []int32) []int {
-	res := make([]int, len(s))
-	for _, i := range s {
-		res = append(res, int(i))
 	}
 	return res
 }

--- a/lightning/checkpoints/checkpoints_sql_test.go
+++ b/lightning/checkpoints/checkpoints_sql_test.go
@@ -111,7 +111,7 @@ func (s *cpSQLSuite) TestNormalOperations(c *C) {
 		ExpectPrepare("REPLACE INTO `mock-schema`\\.chunk_v\\d+ .+")
 	insertChunkStmt.
 		ExpectExec().
-		WithArgs("`db1`.`t2`", 0, "/tmp/path/1.sql", 0, 12, 102400, 1, 5000, 1234567890).
+		WithArgs("`db1`.`t2`", 0, "/tmp/path/1.sql", 0, []byte("null"), 12, 102400, 1, 5000, 1234567890).
 		WillReturnResult(sqlmock.NewResult(10, 1))
 	s.mock.ExpectCommit()
 
@@ -173,7 +173,7 @@ func (s *cpSQLSuite) TestNormalOperations(c *C) {
 		ExpectPrepare("UPDATE `mock-schema`\\.chunk_v\\d+ SET pos = .+").
 		ExpectExec().
 		WithArgs(
-			55904, 681, 4491, 586, 486070148917,
+			55904, 681, 4491, 586, 486070148917, []byte("null"),
 			"`db1`.`t2`", 0, "/tmp/path/1.sql", 0,
 		).
 		WillReturnResult(sqlmock.NewResult(11, 1))

--- a/lightning/mydump/parser.go
+++ b/lightning/mydump/parser.go
@@ -112,6 +112,8 @@ type Parser interface {
 	// Columns returns the _lower-case_ column names corresponding to values in
 	// the LastRow.
 	Columns() []string
+	// SetColumns set restored column names to parser
+	SetColumns([]string)
 
 	SetLogger(log.Logger)
 }
@@ -152,6 +154,10 @@ func (parser *blockParser) Close() error {
 
 func (parser *blockParser) Columns() []string {
 	return parser.columns
+}
+
+func (parser *blockParser) SetColumns(columns []string) {
+	parser.columns = columns
 }
 
 func (parser *blockParser) logSyntaxError() {

--- a/lightning/restore/restore.go
+++ b/lightning/restore/restore.go
@@ -1650,6 +1650,10 @@ func (cr *chunkRestore) deliverLoop(
 			// No need to save checkpoint if nothing was delivered.
 			saveCheckpoint(rc, t, engineID, cr.chunk)
 		}
+		failpoint.Inject("FailAfterWriteRows", func() {
+			time.Sleep(time.Second)
+			panic("forcing failure due to FailAfterWriteRows")
+		})
 		// TODO: for local backend, we may save checkpoint more frequently, e.g. after writen
 		//10GB kv pairs to data engine, we can do a flush for both data & index engine, then we
 		// can safely update current checkpoint.

--- a/lightning/restore/restore.go
+++ b/lightning/restore/restore.go
@@ -72,6 +72,10 @@ var DeliverPauser = common.NewPauser()
 func init() {
 	cfg := tidbcfg.GetGlobalConfig()
 	cfg.Log.SlowThreshold = 3000
+	// used in integration tests
+	failpoint.Inject("SetMinDeliverBytes", func(v failpoint.Value) {
+		minDeliverBytes = v.(int)
+	})
 }
 
 type saveCp struct {
@@ -1553,7 +1557,7 @@ func increaseGCLifeTime(ctx context.Context, db *sql.DB) (err error) {
 
 ////////////////////////////////////////////////////////////////
 
-const (
+var (
 	maxKVQueueSize  = 128   // Cache at most this number of rows before blocking the encode loop
 	minDeliverBytes = 65536 // 64 KB. batch at least this amount of bytes to reduce number of messages
 )

--- a/lightning/restore/restore.go
+++ b/lightning/restore/restore.go
@@ -74,7 +74,7 @@ func init() {
 	cfg.Log.SlowThreshold = 3000
 	// used in integration tests
 	failpoint.Inject("SetMinDeliverBytes", func(v failpoint.Value) {
-		minDeliverBytes = v.(int)
+		minDeliverBytes = uint64(v.(int))
 	})
 }
 
@@ -1558,8 +1558,8 @@ func increaseGCLifeTime(ctx context.Context, db *sql.DB) (err error) {
 ////////////////////////////////////////////////////////////////
 
 var (
-	maxKVQueueSize  = 128   // Cache at most this number of rows before blocking the encode loop
-	minDeliverBytes = 65536 // 64 KB. batch at least this amount of bytes to reduce number of messages
+	maxKVQueueSize         = 128   // Cache at most this number of rows before blocking the encode loop
+	minDeliverBytes uint64 = 65536 // 64 KB. batch at least this amount of bytes to reduce number of messages
 )
 
 type deliveredKVs struct {

--- a/lightning/restore/restore.go
+++ b/lightning/restore/restore.go
@@ -1686,11 +1686,12 @@ func saveCheckpoint(rc *RestoreController, t *TableRestore, engineID int32, chun
 	rc.saveCpCh <- saveCp{
 		tableName: t.tableName,
 		merger: &ChunkCheckpointMerger{
-			EngineID: engineID,
-			Key:      chunk.Key,
-			Checksum: chunk.Checksum,
-			Pos:      chunk.Chunk.Offset,
-			RowID:    chunk.Chunk.PrevRowIDMax,
+			EngineID:          engineID,
+			Key:               chunk.Key,
+			Checksum:          chunk.Checksum,
+			Pos:               chunk.Chunk.Offset,
+			RowID:             chunk.Chunk.PrevRowIDMax,
+			ColumnPermutation: chunk.ColumnPermutation,
 		},
 	}
 }

--- a/lightning/restore/restore_test.go
+++ b/lightning/restore/restore_test.go
@@ -581,7 +581,7 @@ func (s *chunkRestoreSuite) SetUpTest(c *C) {
 	}
 
 	var err error
-	s.cr, err = newChunkRestore(1, s.cfg, &chunk, w)
+	s.cr, err = newChunkRestore(1, s.cfg, &chunk, w, nil)
 	c.Assert(err, IsNil)
 }
 

--- a/tests/checkpoint_columns/config.toml
+++ b/tests/checkpoint_columns/config.toml
@@ -11,6 +11,6 @@ keep-after-success = true
 [mydumper]
 read-block-size = 1
 
-[tikv_importer]
+[tikv-importer]
 max-kv-pairs = 0
 

--- a/tests/checkpoint_columns/config.toml
+++ b/tests/checkpoint_columns/config.toml
@@ -1,0 +1,16 @@
+[lightning]
+table-concurrency = 1
+region-concurrency = 1
+
+[checkpoint]
+enable = true
+schema = "tidb_lightning_checkpoint_test"
+driver = "mysql"
+keep-after-success = true
+
+[mydumper]
+read-block-size = 1
+
+[tikv_importer]
+max-kv-pairs = 0
+

--- a/tests/checkpoint_columns/run.sh
+++ b/tests/checkpoint_columns/run.sh
@@ -21,7 +21,8 @@ DBPATH="$TEST_DIR/cp.mydump"
 mkdir -p $DBPATH
 echo 'CREATE DATABASE cp_tsr;' > "$DBPATH/cp_tsr-schema-create.sql"
 echo "CREATE TABLE tbl(i TINYINT PRIMARY KEY, j INT);" > "$DBPATH/cp_tsr.tbl-schema.sql"
-echo "INSERT INTO tbl (i) VALUES (1),(2);" > "$DBPATH/cp_tsr.tbl.sql"
+# the column orders in data file is different from table schema order.
+echo "INSERT INTO tbl (j, i) VALUES (3, 1),(4, 2);" > "$DBPATH/cp_tsr.tbl.sql"
 
 # Set minDeliverBytes to a small enough number to only write only 1 row each time
 # Set the failpoint to kill the lightning instance as soon as one row is written
@@ -43,5 +44,5 @@ set +e
 run_lightning -d "$DBPATH" --backend tidb --enable-checkpoint=1 2> /dev/null
 set -e
 
-run_sql 'SELECT count(*) FROM `cp_tsr`.tbl'
-check_contains "count(*): 2"
+run_sql 'SELECT j FROM `cp_tsr`.tbl WHERE i = 2;'
+check_contains "j: 4"

--- a/tests/checkpoint_columns/run.sh
+++ b/tests/checkpoint_columns/run.sh
@@ -42,7 +42,7 @@ check_contains "count(*): 1"
 
 export GO_FAILPOINTS=
 set +e
-run_lightning -d "$DBPATH" --backend $BACKEND --enable-checkpoint=1 2> /dev/null
+run_lightning -d "$DBPATH" --backend tidb --enable-checkpoint=1 2> /dev/null
 set -e
 
 run_sql 'SELECT count(*) FROM `cp_tsr`.tbl'

--- a/tests/checkpoint_columns/run.sh
+++ b/tests/checkpoint_columns/run.sh
@@ -24,7 +24,7 @@ mkdir -p $DBPATH
 echo 'CREATE DATABASE cp_tsr;' > "$DBPATH/cp_tsr-schema-create.sql"
 PARTIAL_IMPORT_QUERY='SELECT 0'
 
-echo "CREATE TABLE tbl(i TINYINT PRIMIARY KEY, j INT);" > "$DBPATH/cp_tsr.tbl-schema.sql"
+echo "CREATE TABLE tbl(i TINYINT PRIMARY KEY, j INT);" > "$DBPATH/cp_tsr.tbl-schema.sql"
 echo "INSERT INTO tbl VALUES (1),(2);" > "$DBPATH/cp_tsr.tbl.sql"
 
 # Set the failpoint to kill the lightning instance as soon as one row is write

--- a/tests/checkpoint_columns/run.sh
+++ b/tests/checkpoint_columns/run.sh
@@ -28,7 +28,7 @@ echo "CREATE TABLE tbl(i TINYINT PRIMARY KEY, j INT);" > "$DBPATH/cp_tsr.tbl-sch
 echo "INSERT INTO tbl (i) VALUES (1),(2);" > "$DBPATH/cp_tsr.tbl.sql"
 
 # Set the failpoint to kill the lightning instance as soon as one row is write
-export GO_FAILPOINTS="github.com/pingcap/tidb-lightning/lightning/restore/FailAfterWriteRows=return;github.com/pingcap/tidb-lightning/lightning/restore/SetMinDeliverBytes=return(1);"
+export GO_FAILPOINTS="github.com/pingcap/tidb-lightning/lightning/restore/FailAfterWriteRows=return;github.com/pingcap/tidb-lightning/lightning/restore/SetMinDeliverBytes=return(1)"
 
 # Start importing the tables.
 run_sql 'DROP DATABASE IF EXISTS cp_tsr'
@@ -40,6 +40,7 @@ set -e
 run_sql 'SELECT count(*) FROM `cp_tsr`.tbl'
 check_contains "count(*): 1"
 
+export GO_FAILPOINTS=
 set +e
 run_lightning -d "$DBPATH" --backend $BACKEND --enable-checkpoint=1 2> /dev/null
 set -e

--- a/tests/checkpoint_columns/run.sh
+++ b/tests/checkpoint_columns/run.sh
@@ -1,0 +1,48 @@
+#!/bin/sh
+#
+# Copyright 2019 PingCAP, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -euE
+
+# Populate the mydumper source
+DBPATH="$TEST_DIR/cppk.mydump"
+TABLE_COUNT=1
+CHUNK_COUNT=50
+
+mkdir -p $DBPATH
+echo 'CREATE DATABASE cp_tsr;' > "$DBPATH/cp_tsr-schema-create.sql"
+PARTIAL_IMPORT_QUERY='SELECT 0'
+
+echo "CREATE TABLE tbl(i TINYINT PRIMIARY KEY, j INT);" > "$DBPATH/cp_tsr.tbl-schema.sql"
+echo "INSERT INTO tbl VALUES (1),(2);" > "$DBPATH/cp_tsr.tbl.sql"
+
+# Set the failpoint to kill the lightning instance as soon as one row is write
+export GO_FAILPOINTS="github.com/pingcap/tidb-lightning/lightning/restore/FailAfterWriteRows=return"
+
+# Start importing the tables.
+run_sql 'DROP DATABASE IF EXISTS cp_tsr'
+run_sql 'DROP DATABASE IF EXISTS tidb_lightning_checkpoint_test'
+
+set +e
+run_lightning -d "$DBPATH" --backend tidb --enable-checkpoint=1 2> /dev/null
+set -e
+run_sql 'SELECT count(*) FROM `cp_tsr`.tbl'
+check_contains "count(*): 1"
+
+set +e
+run_lightning -d "$DBPATH" --backend $BACKEND --enable-checkpoint=1 2> /dev/null
+set -e
+
+run_sql 'SELECT count(*) FROM `cp_tsr`.tbl'
+check_contains "count(*): 2"

--- a/tests/checkpoint_columns/run.sh
+++ b/tests/checkpoint_columns/run.sh
@@ -28,7 +28,7 @@ echo "CREATE TABLE tbl(i TINYINT PRIMARY KEY, j INT);" > "$DBPATH/cp_tsr.tbl-sch
 echo "INSERT INTO tbl (i) VALUES (1),(2);" > "$DBPATH/cp_tsr.tbl.sql"
 
 # Set the failpoint to kill the lightning instance as soon as one row is write
-export GO_FAILPOINTS="github.com/pingcap/tidb-lightning/lightning/restore/FailAfterWriteRows=return"
+export GO_FAILPOINTS="github.com/pingcap/tidb-lightning/lightning/restore/FailAfterWriteRows=return;github.com/pingcap/tidb-lightning/lightning/restore/SetMinDeliverBytes=return(1);"
 
 # Start importing the tables.
 run_sql 'DROP DATABASE IF EXISTS cp_tsr'

--- a/tests/checkpoint_columns/run.sh
+++ b/tests/checkpoint_columns/run.sh
@@ -25,7 +25,7 @@ echo 'CREATE DATABASE cp_tsr;' > "$DBPATH/cp_tsr-schema-create.sql"
 PARTIAL_IMPORT_QUERY='SELECT 0'
 
 echo "CREATE TABLE tbl(i TINYINT PRIMARY KEY, j INT);" > "$DBPATH/cp_tsr.tbl-schema.sql"
-echo "INSERT INTO tbl VALUES (1),(2);" > "$DBPATH/cp_tsr.tbl.sql"
+echo "INSERT INTO tbl (i) VALUES (1),(2);" > "$DBPATH/cp_tsr.tbl.sql"
 
 # Set the failpoint to kill the lightning instance as soon as one row is write
 export GO_FAILPOINTS="github.com/pingcap/tidb-lightning/lightning/restore/FailAfterWriteRows=return"


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-Lightning! Please read the [CONTRIBUTING](https://github.com/pingcap/tidb-lightning/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Fix missing column infos when restore from checkpoint

### What is changed and how it works?
- Write Chunk ColumnPermutation to checkpoint db (file/mysql)  when insert or update chunk checkpoints.
- When restore from checkpoint, also restore column infos for parser from stored  `ColumnPermutation`

NOTE: this fix can't handle following case:

table schema:
```
create table t(a varchar(32), b int);
```

data.sql
```
insert into t (a, b) values 
("test1", 1),
("test2", 2);

insert into t (a) values 
("test3"),
("test4");
```

If multi insert statements contains different columns number for their order are different, Mable recover from checkpoint will still fail because we don't update columns infos on the fly. 

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

Side effects

Related changes
