### PR TITLE
backend: use pd tso as commit ts in local and importer backend

### DIFF
--- a/lightning/backend/backend.go
+++ b/lightning/backend/backend.go
@@ -21,6 +21,7 @@ import (
 	"github.com/pingcap/errors"
 	"github.com/pingcap/failpoint"
 	"github.com/pingcap/parser/model"
+	"github.com/pingcap/tidb/store/tikv/oracle"
 	"github.com/pingcap/tidb/table"
 	"github.com/pingcap/tidb/types"
 	uuid "github.com/satori/go.uuid"
@@ -242,7 +243,7 @@ func (be Backend) OpenEngine(ctx context.Context, tableName string, engineID int
 			uuid:    engineUUID,
 		},
 		tableName: tableName,
-		ts:        uint64(time.Now().Unix()), // TODO ... set outside ? from pd ?
+		ts:        oracle.ComposeTS(time.Now().Unix() * 1000, 0),
 	}, nil
 }
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-Lightning! Please read the [CONTRIBUTING](https://github.com/pingcap/tidb-lightning/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Before this commit we use unix timestamp as commit ts for each kv pair in tikv. 
And when we want use commits as filter(e.g. difference backup with BR), this would filter wrong result.
so I think we should encode all commit ts as pd tso.

### What is changed and how it works?
use compose to encode commit ts.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->
- Manual test (add detailed scripts or steps below)

before this commit(local and importer backend are same):
<img width="519" alt="屏幕快照 2020-08-27 下午5 21 52" src="https://user-images.githubusercontent.com/5906259/91422635-04177b00-e88a-11ea-8425-f947248a5926.png">


after this commit(local and importer backend are same):
<img width="564" alt="屏幕快照 2020-08-27 下午5 21 44" src="https://user-images.githubusercontent.com/5906259/91422599-f7932280-e889-11ea-8a44-b34de809e5ac.png">


Related changes

 - Need to cherry-pick to the release branch
 - Need to be included in the release note