### PR TITLE
test: change integration test script to allow run tests in parallel

### DIFF
--- a/tests/run.sh
+++ b/tests/run.sh
@@ -169,8 +169,8 @@ fi
 echo "selected test cases: $SELECTED_TEST_NAME"
 
 for casename in $SELECTED_TEST_NAME; do
-  script=tests/$casename/run.sh
-  echo "\x1b[32;1m@@@@@@@ Running test $script...\x1b[0m"
+    script=tests/$casename/run.sh
+    echo "\x1b[32;1m@@@@@@@ Running test $script...\x1b[0m"
     TEST_DIR="$TEST_DIR" \
     TEST_NAME="$casename" \
     CLUSTER_VERSION_MAJOR="${CLUSTER_VERSION_MAJOR#v}" \

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -14,9 +14,8 @@
 # limitations under the License.
 
 set -eu
-
 TEST_DIR=/tmp/lightning_test_result
-SELECTED_TEST_NAME="${TEST_NAME-*}"
+SELECTED_TEST_NAME="${TEST_NAME-$(find tests -mindepth 2 -maxdepth 2 -name run.sh | cut -d/ -f2 | sort)}"
 export PATH="tests/_utils:$PATH"
 
 stop_services() {
@@ -167,12 +166,16 @@ if [ "${1-}" = '--debug' ]; then
     read line
 fi
 
-for script in tests/$SELECTED_TEST_NAME/run.sh; do
-    echo "\x1b[32;1m@@@@@@@ Running test $script...\x1b[0m"
+echo "selected test cases: $SELECTED_TEST_NAME"
+
+for casename in $SELECTED_TEST_NAME; do
+  script=tests/$casename/run.sh
+  echo "\x1b[32;1m@@@@@@@ Running test $script...\x1b[0m"
     TEST_DIR="$TEST_DIR" \
-    TEST_NAME="$(basename "$(dirname "$script")")" \
+    TEST_NAME="$casename" \
     CLUSTER_VERSION_MAJOR="${CLUSTER_VERSION_MAJOR#v}" \
     CLUSTER_VERSION_MINOR="$CLUSTER_VERSION_MINOR" \
     CLUSTER_VERSION_REVISION="$CLUSTER_VERSION_REVISION" \
     sh "$script"
 done
+

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -168,6 +168,9 @@ fi
 
 echo "selected test cases: $SELECTED_TEST_NAME"
 
+# disable cluster index by default
+run_sql 'set @@global.tidb_enable_clustered_index = 0' || echo "tidb does not support cluster index yet, skipped!"
+
 for casename in $SELECTED_TEST_NAME; do
     script=tests/$casename/run.sh
     echo "\x1b[32;1m@@@@@@@ Running test $script...\x1b[0m"


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-Lightning! Please read the [CONTRIBUTING](https://github.com/pingcap/tidb-lightning/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Currently, when we exec `TEST_NAME=... tests/run.sh`,  this will actually run all tests that name start with `TEST_NAME`. 
This pr change the meaning for `TEST_NAME` to contain one or more  test case name, and the script will only run these cases. By these way we can control the concurrency to exec the test cases. 

After this change, we can update our ci script to run integration test in parallel, see this example: https://internal.pingcap.net/idc-jenkins/blue/organizations/jenkins/lightning_ghpr_test/detail/lightning_ghpr_test/1507/pipeline/53

### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

Side effects

 - Change the meaning of `TEST_NAME`, so if some job depend on this, they may fail.

Related changes
