### PR TITLE
test: fix integration test for 3.x version

### DIFF
--- a/tests/checkpoint_error_destroy/file.toml
+++ b/tests/checkpoint_error_destroy/file.toml
@@ -1,3 +1,4 @@
 [checkpoint]
 enable = true
 driver = "file"
+dsn = "/tmp/cp_error_destroy.pb"

--- a/tests/checkpoint_error_destroy/run.sh
+++ b/tests/checkpoint_error_destroy/run.sh
@@ -33,6 +33,10 @@ check_contains 'x: 1999-09-09 09:09:09'
 
 run_sql 'DROP DATABASE cped'
 
+CHECK_POINT_FILE="/tmp/cp_error_destroy.pb"
+
+# clean up possible old files
+rm -rf CHECK_POINT_FILE
 for i in $(seq 8); do
     ARGS="--enable-checkpoint=1 --config tests/$TEST_NAME/file.toml -d tests/$TEST_NAME/bad-data"
     set +e

--- a/tests/common_handle/run.sh
+++ b/tests/common_handle/run.sh
@@ -36,6 +36,7 @@ INSERT INTO t (s, i, j) VALUES
   ("this_is_test4", 4, 4),
   ("this_is_test5", 5, 5);
 _EOF_
+echo 'INSERT INTO t(s, i, j) VALUES ("another test case", 6, 6);' > $DB_PATH/ch.t.1.sql
 
 for BACKEND in local importer tidb; do
   # Start importing the tables.
@@ -44,12 +45,12 @@ for BACKEND in local importer tidb; do
   run_lightning -d "$DBPATH" --backend $BACKEND 2> /dev/null
 
   run_sql 'SELECT count(*), sum(i) FROM `ch`.t'
-  check_contains "count(*): 5"
-  check_contains "sum(i): 15"
+  check_contains "count(*): 6"
+  check_contains "sum(i): 21"
 
   # check table kv pairs. common hanle should have no extra index kv-paris
-  run_sql "ADMIN CHECKSUM TABLE `ch`.t"
-  check_contains "Total_kvs: 5"
+  run_sql 'ADMIN CHECKSUM TABLE `ch`.t'
+  check_contains "Total_kvs: 6"
 done
 
 # restore global variables, other tests needs this to handle the _tidb_row_id column

--- a/tests/common_handle/run.sh
+++ b/tests/common_handle/run.sh
@@ -36,7 +36,7 @@ INSERT INTO t (s, i, j) VALUES
   ("this_is_test4", 4, 4),
   ("this_is_test5", 5, 5);
 _EOF_
-echo 'INSERT INTO t(s, i, j) VALUES ("another test case", 6, 6);' > $DB_PATH/ch.t.1.sql
+echo 'INSERT INTO t(s, i, j) VALUES ("another test case", 6, 6);' > "$DBPATH/ch.t.1.sql"
 
 for BACKEND in local importer tidb; do
   # Start importing the tables.

--- a/tests/common_handle/run.sh
+++ b/tests/common_handle/run.sh
@@ -46,6 +46,10 @@ for BACKEND in local importer tidb; do
   run_sql 'SELECT count(*), sum(i) FROM `ch`.t'
   check_contains "count(*): 5"
   check_contains "sum(i): 15"
+
+  # check table kv pairs. common hanle should have no extra index kv-paris
+  run_sql "ADMIN CHECKSUM TABLE `ch`.t"
+  check_contains "Total_kvs: 5"
 done
 
 # restore global variables, other tests needs this to handle the _tidb_row_id column

--- a/tests/common_handle/run.sh
+++ b/tests/common_handle/run.sh
@@ -16,7 +16,7 @@
 check_cluster_version 4 0 0 'local backend' || exit 0
 
 # enable cluster index
-run_sql 'set @@global.tidb_enable_clustered_index = 1' || echo "tidb does not support cluster index yet, skip this test!" && exit 0
+run_sql 'set @@global.tidb_enable_clustered_index = 1' || (echo "tidb does not support cluster index yet, skip this test!" && exit 0)
 # wait for global variable cache invalid
 sleep 2
 

--- a/tests/file_routing/run.sh
+++ b/tests/file_routing/run.sh
@@ -35,18 +35,13 @@ for BACKEND in local importer; do
   echo "INSERT INTO tbl (i, j) VALUES (10, 10);" > "$DBPATH/ff/test.SQL"
   echo "INSERT INTO tbl (i, j) VALUES (11, 11);" > "$DBPATH/fr/tbl-noused.sql"
 
-  # Set minDeliverBytes to a small enough number to only write only 1 row each time
-  # Set the failpoint to kill the lightning instance as soon as one row is written
-
-  # Start importing the tables.
   run_sql 'DROP DATABASE IF EXISTS fr'
-
-  set +e
+  
+  # Start importing the tables.
   run_lightning -d "$DBPATH" --backend $BACKEND 2> /dev/null
-  set -e
+
   run_sql 'SELECT count(*) FROM `fr`.tbl'
   check_contains "count(*): 10"
-
   run_sql 'SELECT sum(j) FROM `fr`.tbl'
   check_contains "sum(j): 55"
 done

--- a/tests/file_routing/run.sh
+++ b/tests/file_routing/run.sh
@@ -15,31 +15,38 @@
 
 set -euE
 
-# Populate the mydumper source
-DBPATH="$TEST_DIR/fr.mydump"
+for BACKEND in local importer; do
 
-mkdir -p $DBPATH $DBPATH/fr $DBPATH/ff
-echo 'CREATE DATABASE fr;' > "$DBPATH/fr/schema.sql"
-echo "CREATE TABLE tbl(i TINYINT PRIMARY KEY, j INT);" > "$DBPATH/fr/tbl-table.sql"
-# the column orders in data file is different from table schema order.
-echo "INSERT INTO tbl (i, j) VALUES (1, 1),(2, 2);" > "$DBPATH/fr/tbl1.sql.0"
-echo "INSERT INTO tbl (i, j) VALUES (3, 3),(4, 4);" > "$DBPATH/fr/tbl2.sql.0"
-echo "INSERT INTO tbl (i, j) VALUES (5, 5);" > "$DBPATH/fr/tbl.sql"
-echo "INSERT INTO tbl (i, j) VALUES (6, 6), (7, 7), (8, 8), (9, 9);" > "$DBPATH/tbl1.sql.1"
-echo "INSERT INTO tbl (i, j) VALUES (10, 10);" > "$DBPATH/ff/test.SQL"
-echo "INSERT INTO tbl (i, j) VALUES (11, 11);" > "$DBPATH/fr/tbl-noused.sql"
+  if [ "$BACKEND" = 'local' ]; then
+    check_cluster_version 4 0 0 'local backend' || continue
+  fi
 
-# Set minDeliverBytes to a small enough number to only write only 1 row each time
-# Set the failpoint to kill the lightning instance as soon as one row is written
+  # Populate the mydumper source
+  DBPATH="$TEST_DIR/fr.mydump"
 
-# Start importing the tables.
-run_sql 'DROP DATABASE IF EXISTS fr'
+  mkdir -p $DBPATH $DBPATH/fr $DBPATH/ff
+  echo 'CREATE DATABASE fr;' > "$DBPATH/fr/schema.sql"
+  echo "CREATE TABLE tbl(i TINYINT PRIMARY KEY, j INT);" > "$DBPATH/fr/tbl-table.sql"
+  # the column orders in data file is different from table schema order.
+  echo "INSERT INTO tbl (i, j) VALUES (1, 1),(2, 2);" > "$DBPATH/fr/tbl1.sql.0"
+  echo "INSERT INTO tbl (i, j) VALUES (3, 3),(4, 4);" > "$DBPATH/fr/tbl2.sql.0"
+  echo "INSERT INTO tbl (i, j) VALUES (5, 5);" > "$DBPATH/fr/tbl.sql"
+  echo "INSERT INTO tbl (i, j) VALUES (6, 6), (7, 7), (8, 8), (9, 9);" > "$DBPATH/tbl1.sql.1"
+  echo "INSERT INTO tbl (i, j) VALUES (10, 10);" > "$DBPATH/ff/test.SQL"
+  echo "INSERT INTO tbl (i, j) VALUES (11, 11);" > "$DBPATH/fr/tbl-noused.sql"
 
-set +e
-run_lightning -d "$DBPATH" --backend local 2> /dev/null
-set -e
-run_sql 'SELECT count(*) FROM `fr`.tbl'
-check_contains "count(*): 10"
+  # Set minDeliverBytes to a small enough number to only write only 1 row each time
+  # Set the failpoint to kill the lightning instance as soon as one row is written
 
-run_sql 'SELECT sum(j) FROM `fr`.tbl'
-check_contains "sum(j): 55"
+  # Start importing the tables.
+  run_sql 'DROP DATABASE IF EXISTS fr'
+
+  set +e
+  run_lightning -d "$DBPATH" --backend $BACKEND 2> /dev/null
+  set -e
+  run_sql 'SELECT count(*) FROM `fr`.tbl'
+  check_contains "count(*): 10"
+
+  run_sql 'SELECT sum(j) FROM `fr`.tbl'
+  check_contains "sum(j): 55"
+done

--- a/tests/file_routing/run.sh
+++ b/tests/file_routing/run.sh
@@ -15,28 +15,27 @@
 
 set -euE
 
-for BACKEND in local importer; do
+# Populate the mydumper source
+DBPATH="$TEST_DIR/fr.mydump"
 
+mkdir -p $DBPATH $DBPATH/fr $DBPATH/ff
+echo 'CREATE DATABASE fr;' > "$DBPATH/fr/schema.sql"
+echo "CREATE TABLE tbl(i TINYINT PRIMARY KEY, j INT);" > "$DBPATH/fr/tbl-table.sql"
+# the column orders in data file is different from table schema order.
+echo "INSERT INTO tbl (i, j) VALUES (1, 1),(2, 2);" > "$DBPATH/fr/tbl1.sql.0"
+echo "INSERT INTO tbl (i, j) VALUES (3, 3),(4, 4);" > "$DBPATH/fr/tbl2.sql.0"
+echo "INSERT INTO tbl (i, j) VALUES (5, 5);" > "$DBPATH/fr/tbl.sql"
+echo "INSERT INTO tbl (i, j) VALUES (6, 6), (7, 7), (8, 8), (9, 9);" > "$DBPATH/tbl1.sql.1"
+echo "INSERT INTO tbl (i, j) VALUES (10, 10);" > "$DBPATH/ff/test.SQL"
+echo "INSERT INTO tbl (i, j) VALUES (11, 11);" > "$DBPATH/fr/tbl-noused.sql"
+
+for BACKEND in local importer; do
   if [ "$BACKEND" = 'local' ]; then
     check_cluster_version 4 0 0 'local backend' || continue
   fi
 
-  # Populate the mydumper source
-  DBPATH="$TEST_DIR/fr.mydump"
-
-  mkdir -p $DBPATH $DBPATH/fr $DBPATH/ff
-  echo 'CREATE DATABASE fr;' > "$DBPATH/fr/schema.sql"
-  echo "CREATE TABLE tbl(i TINYINT PRIMARY KEY, j INT);" > "$DBPATH/fr/tbl-table.sql"
-  # the column orders in data file is different from table schema order.
-  echo "INSERT INTO tbl (i, j) VALUES (1, 1),(2, 2);" > "$DBPATH/fr/tbl1.sql.0"
-  echo "INSERT INTO tbl (i, j) VALUES (3, 3),(4, 4);" > "$DBPATH/fr/tbl2.sql.0"
-  echo "INSERT INTO tbl (i, j) VALUES (5, 5);" > "$DBPATH/fr/tbl.sql"
-  echo "INSERT INTO tbl (i, j) VALUES (6, 6), (7, 7), (8, 8), (9, 9);" > "$DBPATH/tbl1.sql.1"
-  echo "INSERT INTO tbl (i, j) VALUES (10, 10);" > "$DBPATH/ff/test.SQL"
-  echo "INSERT INTO tbl (i, j) VALUES (11, 11);" > "$DBPATH/fr/tbl-noused.sql"
-
   run_sql 'DROP DATABASE IF EXISTS fr'
-  
+
   # Start importing the tables.
   run_lightning -d "$DBPATH" --backend $BACKEND 2> /dev/null
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-Lightning! Please read the [CONTRIBUTING](https://github.com/pingcap/tidb-lightning/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
- Skip run test `file-routing` with local backend when verion < v4.0.0
- Run integration test `common_handle` for all 3 backend
- fix a occasional test failure for `checkpoint_error_destroy` do to remain checkpoint file by other test.  see: https://internal.pingcap.net/idc-jenkins/blue/organizations/jenkins/lightning_ghpr_test/detail/lightning_ghpr_test/1720/pipeline/

close #388

### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

Side effects

Related changes
