### PR TITLE
backend: use peer address as grpc addr for tiflash store

### DIFF
--- a/lightning/backend/local.go
+++ b/lightning/backend/local.go
@@ -200,9 +200,14 @@ func (local *local) getGrpcConnLocked(ctx context.Context, storeID uint64) (*grp
 
 	bfConf := backoff.DefaultConfig
 	bfConf.MaxDelay = gRPCBackOffMaxDelay
+	// we should use peer address for tiflash. for tikv, peer address is empty
+	addr := store.GetPeerAddress()
+	if addr == "" {
+		addr = store.GetAddress()
+	}
 	conn, err := grpc.DialContext(
 		ctx,
-		store.GetAddress(),
+		addr,
 		opt,
 		grpc.WithConnectParams(grpc.ConnectParams{Backoff: bfConf}),
 		grpc.WithKeepaliveParams(keepalive.ClientParameters{

--- a/tests/README.md
+++ b/tests/README.md
@@ -5,12 +5,14 @@ programs.
 
 ## Preparations
 
-1. The following four executables must be copied or linked into these locations:
+1. The following 6 executables must be copied or linked into these locations:
 
     * `bin/pd-server`
     * `bin/tikv-server`
     * `bin/tidb-server`
     * `bin/tikv-importer`
+    * `bin/tiflash`
+    * `bin/minio`
 
     The versions must be ≥2.1.0 as usual.
 

--- a/tests/_utils/check_cluster_version
+++ b/tests/_utils/check_cluster_version
@@ -15,9 +15,9 @@
 
 set -eu
 
-if [ "$CLUSTER_VERSION_MAJOR" -gt "$1" ] || [ "$CLUSTER_VERSION_MAJOR" -eq "$1" ] && ( \
+if [ "$CLUSTER_VERSION_MAJOR" -gt "$1" ] || ([ "$CLUSTER_VERSION_MAJOR" -eq "$1" ] && ( \
     [ "$CLUSTER_VERSION_MINOR" -gt "$2" ] || \
-    [ "$CLUSTER_VERSION_MINOR" -eq "$2" ] && [ "$CLUSTER_VERSION_REVISION" -ge "$3" ] )
+    [ "$CLUSTER_VERSION_MINOR" -eq "$2" ] && [ "$CLUSTER_VERSION_REVISION" -ge "$3" ] ))
 then
     exit 0
 fi

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -259,7 +259,7 @@ EOF
     i=0
     while ! run_curl https://127.0.0.1:8125 1>/dev/null 2>&1; do
         i=$((i+1))
-        if [ "$i" -gt 20 ]; then
+        if [ "$i" -gt 60 ]; then
             echo "failed to start tiflash"
             return 1
         fi

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -23,6 +23,7 @@ stop_services() {
     killall -9 pd-server || true
     killall -9 tidb-server || true
     killall -9 tikv-importer || true
+    killall -9 tiflash || true
 
     find "$TEST_DIR" -maxdepth 1 -not -path "$TEST_DIR" -not -name "cov.*" -not -name "*.log" | xargs rm -r || true
 }
@@ -149,6 +150,89 @@ EOF
             echo 'Failed to start TiDB'
             exit 1
         fi
+        sleep 3
+    done
+
+    cat - > "$TEST_DIR/tiflash.toml" <<EOF
+default_profile = "default"
+display_name = "TiFlash"
+http_port = 8125
+listen_host = "0.0.0.0"
+mark_cache_size = 5368709120
+path = "$TEST_DIR/tiflash/data"
+tcp_port = 9002
+tmp_path = "/tmp/tiflash"
+
+[application]
+runAsDaemon = true
+
+[flash]
+service_addr = "127.0.0.1:3930"
+tidb_status_addr = "127.0.0.1:10080"
+
+[flash.proxy]
+config = "$PWD/tests/config/tiflash-learner.toml"
+log-file = "$TEST_DIR/tiflash-proxy.log"
+
+[flash.flash_cluster]
+cluster_manager_path = "$PWD/bin/flash_cluster_manager"
+log = "$TEST_DIR/tiflash-manager.log"
+master_ttl = 60
+refresh_interval = 20
+update_rule_interval = 5
+
+[logger]
+count = 20
+level = "trace"
+log = "$TEST_DIR/tiflash-stdout.log"
+errorlog = "$TEST_DIR/tiflash-stderr.log"
+size = "1000M"
+
+[raft]
+pd_addr = "127.0.0.1:2379"
+
+[profiles]
+[profiles.default]
+load_balancing = "random"
+max_memory_usage = 10000000000
+use_uncompressed_cache = 0
+
+[users]
+[users.default]
+password = ""
+profile = "default"
+quota = "default"
+[users.default.networks]
+ip = "::/0"
+[users.readonly]
+password = ""
+profile = "readonly"
+quota = "default"
+[users.readonly.networks]
+ip = "::/0"
+
+[quotas]
+[quotas.default]
+[quotas.default.interval]
+duration = 3600
+errors = 0
+execution_time = 0
+queries = 0
+read_rows = 0
+result_rows = 0
+EOF
+    echo "Starting TiFlash..."
+    LD_LIBRARY_PATH=bin/ bin/tiflash server --config-file="$TEST_DIR/tiflash.toml" &
+    echo "TiFlash started..."
+
+    i=0
+    while ! curl -sf http://127.0.0.1:8125 1>/dev/null 2>&1; do
+        i=$((i+1))
+        if [ "$i" -gt 20 ]; then
+            echo "failed to start tiflash"
+            return 1
+        fi
+        echo "TiFlash seems doesn't started, retrying..."
         sleep 3
     done
 }

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -181,11 +181,11 @@ eof
     cat - > "$TEST_DIR/tiflash.toml" <<EOF
 default_profile = "default"
 display_name = "TiFlash"
-http_port = 8125
+https_port = 8125
 listen_host = "0.0.0.0"
 mark_cache_size = 5368709120
 path = "$TEST_DIR/tiflash/data"
-tcp_port = 9002
+tcp_port_secure = 9002
 tmp_path = "/tmp/tiflash"
 
 [application]
@@ -298,4 +298,3 @@ for casename in $SELECTED_TEST_NAME; do
     CLUSTER_VERSION_REVISION="$CLUSTER_VERSION_REVISION" \
     sh "$script"
 done
-

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -54,7 +54,7 @@ EOF
     openssl ecparam -out "$TT/ca.key" -name prime256v1 -genkey
     openssl req -new -batch -sha256 -subj '/CN=localhost' -key "$TT/ca.key" -out "$TT/ca.csr"
     openssl x509 -req -sha256 -days 2 -in "$TT/ca.csr" -signkey "$TT/ca.key" -out "$TT/ca.pem" 2> /dev/null
-    for cluster in tidb pd tikv importer lightning curl; do
+    for cluster in tidb pd tikv importer lightning tiflash curl; do
         openssl ecparam -out "$TT/$cluster.key" -name prime256v1 -genkey
         openssl req -new -batch -sha256 -subj '/CN=localhost' -key "$TT/$cluster.key" -out "$TT/$cluster.csr"
         openssl x509 -req -sha256 -days 1 -extensions EXT -extfile "$TT/ipsan.cnf" -in "$TT/$cluster.csr" -CA "$TT/ca.pem" -CAkey "$TT/ca.key" -CAcreateserial -out "$TT/$cluster.pem" 2> /dev/null
@@ -64,8 +64,14 @@ EOF
 data-dir = "$TEST_DIR/pd"
 client-urls = "https://127.0.0.1:2379"
 peer-urls = "https://127.0.0.1:2380"
+
 [log.file]
 filename = "$TEST_DIR/pd.log"
+
+[replication]
+enable-placement-rules = true
+max-replicas = 1
+
 [security]
 cacert-path = "$TT/ca.pem"
 cert-path = "$TT/pd.pem"
@@ -153,6 +159,25 @@ EOF
         sleep 3
     done
 
+    cat > $TEST_DIR/tiflash-learner.toml <<eof
+[rocksdb]
+wal-dir = ""
+
+[security]
+ca-path = "$TT/ca.pem"
+cert-path = "$TT/tiflash.pem"
+key-path = "$TT/tiflash.key"
+
+[server]
+addr = "0.0.0.0:20170"
+advertise-addr = "127.0.0.1:20170"
+engine-addr = "127.0.0.1:3930"
+status-addr = "127.0.0.1:17000"
+
+[storage]
+data-dir = "$TEST_DIR/tiflash/data"
+eof
+
     cat - > "$TEST_DIR/tiflash.toml" <<EOF
 default_profile = "default"
 display_name = "TiFlash"
@@ -171,7 +196,7 @@ service_addr = "127.0.0.1:3930"
 tidb_status_addr = "127.0.0.1:10080"
 
 [flash.proxy]
-config = "$PWD/tests/config/tiflash-learner.toml"
+config = "$TEST_DIR/tiflash-learner.toml"
 log-file = "$TEST_DIR/tiflash-proxy.log"
 
 [flash.flash_cluster]
@@ -220,13 +245,19 @@ execution_time = 0
 queries = 0
 read_rows = 0
 result_rows = 0
+
+[security]
+ca_path = "$TT/ca.pem"
+cert_path = "$TT/tiflash.pem"
+key_path = "$TT/tiflash.key"
 EOF
+    rm -rf $TEST_DIR/tiflash /tmp/tiflash
     echo "Starting TiFlash..."
     LD_LIBRARY_PATH=bin/ bin/tiflash server --config-file="$TEST_DIR/tiflash.toml" &
     echo "TiFlash started..."
 
     i=0
-    while ! curl -sf http://127.0.0.1:8125 1>/dev/null 2>&1; do
+    while ! run_curl https://127.0.0.1:8125 1>/dev/null 2>&1; do
         i=$((i+1))
         if [ "$i" -gt 20 ]; then
             echo "failed to start tiflash"

--- a/tests/tiflash/config.toml
+++ b/tests/tiflash/config.toml
@@ -1,0 +1,2 @@
+[tikv-importer]
+region-split-size = 20

--- a/tests/tiflash/config.toml
+++ b/tests/tiflash/config.toml
@@ -1,2 +1,2 @@
-[tikv-importer]
-region-split-size = 20
+[mydumper]
+no-schema = true

--- a/tests/tiflash/run.sh
+++ b/tests/tiflash/run.sh
@@ -1,0 +1,57 @@
+#!/bin/sh
+#
+# Copyright 2019 PingCAP, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+check_cluster_version 3 1 0 'TiFlash' || exit 0
+
+set -euE
+
+# Populate the mydumper source
+DBPATH="$TEST_DIR/tiflash.mydump"
+
+mkdir -p $DBPATH
+DB=test_tiflash
+
+run_sql "DROP DATABASE IF EXISTS $DB"
+run_sql "CREATE DATABASE $DB"
+run_sql "CREATE TABLE $DB.t1 (i INT, j INT, s varchar(32), PRIMARY KEY(s, i));"
+run_sql "ALTER TABLE $DB.t1 SET TIFLASH REPLICA 1;"
+run_sql "CREATE TABLE $DB.t2 (i INT, j TINYINT);"
+run_sql "ALTER TABLE $DB.t2 SET TIFLASH REPLICA 1;"
+
+
+cat > "$DBPATH/$DB.t1.0.sql" << _EOF_
+INSERT INTO t1 (s, i, j) VALUES
+  ("this_is_test1", 1, 1),
+  ("this_is_test2", 2, 2),
+  ("this_is_test3", 3, 3),
+  ("this_is_test4", 4, 4),
+  ("this_is_test5", 5, 5);
+_EOF_
+
+echo "INSERT INTO t2 VALUES (1, 1), (2, 2)" > "$DBPATH/$DB.t2.0.sql"
+echo "INSERT INTO t2 VALUES (3, 3), (4, 4)" > "$DBPATH/$DB.t2.1.sql"
+
+for BACKEND in local importer tidb; do
+  run_lightning -d "$DBPATH" --backend local 2> /dev/null
+
+  run_sql "SELECT /*+ read_from_storage(tiflash[t1]) */ count(*), sum(i) FROM \`$DB\`.t1"
+  check_contains "count(*): 5"
+  check_contains "sum(i): 15"
+
+  run_sql "SELECT /*+ read_from_storage(tiflash[t2]) */ count(*), sum(i) FROM \`$DB\`.t2"
+  check_contains "count(*): 4"
+  check_contains "sum(i): 10"
+
+done

--- a/tests/tiflash/run.sh
+++ b/tests/tiflash/run.sh
@@ -37,7 +37,7 @@ echo "INSERT INTO t2 VALUES (3, 3), (4, 4)" > "$DBPATH/$DB.t2.1.sql"
 
 tiflash_replica_ready() {
   i=0
-  run_sql "select sum(AVAILABLE) as s from information_schema.tiflash_replica WHERE TABLE_NAME = \"$1\""
+  run_sql "select sum(AVAILABLE) from information_schema.tiflash_replica WHERE TABLE_NAME = \"$1\""
   while ! check_contains "sum(AVAILABLE): 1" check; do
     i=$((i+1))
     if [ "$i" -gt 30 ]; then
@@ -45,6 +45,7 @@ tiflash_replica_ready() {
         return 1
     fi
     sleep 1
+    run_sql "select sum(AVAILABLE) from information_schema.tiflash_replica WHERE TABLE_NAME = \"$1\""
   done
 }
 

--- a/tests/tiflash/run.sh
+++ b/tests/tiflash/run.sh
@@ -40,11 +40,11 @@ tiflash_replica_ready() {
   run_sql "select sum(AVAILABLE) from information_schema.tiflash_replica WHERE TABLE_NAME = \"$1\""
   while ! check_contains "sum(AVAILABLE): 1" check; do
     i=$((i+1))
-    if [ "$i" -gt 30 ]; then
+    if [ "$i" -gt 100 ]; then
         echo "wait tiflash replica ready timeout"
         return 1
     fi
-    sleep 1
+    sleep 3
     run_sql "select sum(AVAILABLE) from information_schema.tiflash_replica WHERE TABLE_NAME = \"$1\""
   done
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-Lightning! Please read the [CONTRIBUTING](https://github.com/pingcap/tidb-lightning/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
close #391 

### What is changed and how it works?
Use `store.GetPeerAddress` as the address to open gRPC connect and add a integration test for tiflash

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

Side effects

Related changes
