### PR TITLE
loader: fix store.WalkDir return inaccurate file size for soft link source files

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/joho/sqltocsv v0.0.0-20190824231449-5650f27fd5b6
 	github.com/juju/loggo v0.0.0-20180524022052-584905176618 // indirect
 	github.com/onsi/ginkgo v1.13.0 // indirect
-	github.com/pingcap/br v0.0.0-20200903160657-0fcfd5be4b93
+	github.com/pingcap/br v0.0.0-20200909093836-36281d93ab13
 	github.com/pingcap/check v0.0.0-20200212061837-5e12011dc712
 	github.com/pingcap/errors v0.11.5-0.20200729012136-4e113ddee29e
 	github.com/pingcap/failpoint v0.0.0-20200603062251-b230c36c413c

--- a/go.sum
+++ b/go.sum
@@ -471,8 +471,8 @@ github.com/pingcap/br v0.0.0-20200803052654-e6f63fc1807a/go.mod h1:8j7vGUfHCETYb
 github.com/pingcap/br v0.0.0-20200805121136-181c081ba6ac h1:UTDTEFuFdS/cyCqYAcp8rWBfG8qJnzHIckC5FPUKfqw=
 github.com/pingcap/br v0.0.0-20200805121136-181c081ba6ac/go.mod h1:9P24mNzNmXjggYBm4pnb08slSbua8FA6QIyg68GpuhQ=
 github.com/pingcap/br v0.0.0-20200820083933-d9d6207c0aa7/go.mod h1:5ri8663t7CtJuG0kiOKKoBmwk9HOCX5MoKpmh1fW4CE=
-github.com/pingcap/br v0.0.0-20200903160657-0fcfd5be4b93 h1:21WD99nwr4v3PYWMXYE/FogA1lY7r01PZYAdBHLQ1c8=
-github.com/pingcap/br v0.0.0-20200903160657-0fcfd5be4b93/go.mod h1:DGsMcZVYt2haeDF/xGerf77c2RpTymgYY5+bMg8uArA=
+github.com/pingcap/br v0.0.0-20200909093836-36281d93ab13 h1:TdUSKo9KZrIOTqAy3h/OqS+3PEvpTFe32+ymdpLjVAE=
+github.com/pingcap/br v0.0.0-20200909093836-36281d93ab13/go.mod h1:DGsMcZVYt2haeDF/xGerf77c2RpTymgYY5+bMg8uArA=
 github.com/pingcap/check v0.0.0-20190102082844-67f458068fc8/go.mod h1:B1+S9LNcuMyLH/4HMTViQOJevkGiik3wW2AN9zb2fNQ=
 github.com/pingcap/check v0.0.0-20191107115940-caf2b9e6ccf4/go.mod h1:PYMCGwN0JHjoqGr3HrZoD+b8Tgx8bKnArhSq8YVzUMc=
 github.com/pingcap/check v0.0.0-20191216031241-8a5a85928f12/go.mod h1:PYMCGwN0JHjoqGr3HrZoD+b8Tgx8bKnArhSq8YVzUMc=

--- a/lightning/checkpoints/checkpoints_sql_test.go
+++ b/lightning/checkpoints/checkpoints_sql_test.go
@@ -481,6 +481,9 @@ func (s *cpSQLSuite) TestMoveCheckpoints(c *C) {
 	s.mock.
 		ExpectExec("RENAME TABLE `mock-schema`\\.table_v\\d+ TO `mock-schema\\.12345678\\.bak`\\.table_v\\d+").
 		WillReturnResult(sqlmock.NewResult(0, 1))
+	s.mock.
+		ExpectExec("RENAME TABLE `mock-schema`\\.task_v\\d+ TO `mock-schema\\.12345678\\.bak`\\.task_v\\d+").
+		WillReturnResult(sqlmock.NewResult(0, 1))
 
 	err := s.cpdb.MoveCheckpoints(ctx, 12345678)
 	c.Assert(err, IsNil)

--- a/tests/source_linkfile/config.toml
+++ b/tests/source_linkfile/config.toml
@@ -1,0 +1,2 @@
+[lightning]
+table-concurrency = 4

--- a/tests/source_linkfile/config.toml
+++ b/tests/source_linkfile/config.toml
@@ -1,2 +1,1 @@
 [lightning]
-table-concurrency = 4

--- a/tests/source_linkfile/run.sh
+++ b/tests/source_linkfile/run.sh
@@ -28,16 +28,16 @@ ROW_COUNT=1000
 
 echo "CREATE DATABASE $DB;" > "$RAW_PATH/$DB-schema-create.sql"
 echo "CREATE TABLE t(s varchar(64), i INT, j TINYINT,  PRIMARY KEY(s, i));" > "$RAW_PATH/$DB.t-schema.sql"
-echo "CREATE TABLE t2(i INT PRIMARY KEY, s varchar(32))" > "$RAW_PATH/$DB.t2-schema.sql"
+echo "CREATE TABLE t2(i INT PRIMARY KEY, s varchar(32));" > "$RAW_PATH/$DB.t2-schema.sql"
 
-echo "s,i,j" > "$RAW_PATH/$DB.t.0.sql"
+echo "s,i,j" > "$RAW_PATH/$DB.t.0.csv"
 for i in $(seq "$ROW_COUNT"); do
-    echo "\"thisisastringvalues_line$i\",$i,$i" >> "$RAW_PATH/$DB.t.0.sql"
+    echo "\"thisisastringvalues_line$i\",$i,$i" >> "$RAW_PATH/$DB.t.0.csv"
 done
 
-echo "i,s" > "$RAW_PATH/$DB.t.0.sql"
+echo "i,s" > "$RAW_PATH/$DB.t2.0.csv"
 for i in $(seq $ROW_COUNT); do
-  echo "$i,\"test123ataettaet$i\"" >> "$RAW_PATH/$DB.t2.0.sql"
+  echo "$i,\"test123ataettaet$i\"" >> "$RAW_PATH/$DB.t2.0.csv"
 done
 
 # link source files to source dir

--- a/tests/source_linkfile/run.sh
+++ b/tests/source_linkfile/run.sh
@@ -26,7 +26,7 @@ DB=linkfiles
 
 ROW_COUNT=1000
 
-echo "CREATE DATABASE $DB;" > "$RAW_PATH/ch-schema-create.sql"
+echo "CREATE DATABASE $DB;" > "$RAW_PATH/$DB-schema-create.sql"
 echo "CREATE TABLE t(s varchar(64), i INT, j TINYINT,  PRIMARY KEY(s, i));" > "$RAW_PATH/$DB.t-schema.sql"
 echo "CREATE TABLE t2(i INT PRIMARY KEY, s varchar(32))" > "$RAW_PATH/$DB.t2-schema.sql"
 

--- a/tests/source_linkfile/run.sh
+++ b/tests/source_linkfile/run.sh
@@ -1,0 +1,54 @@
+#!/bin/sh
+#
+# Copyright 2019 PingCAP, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# test source dir that contains soft/hard link files
+
+set -euE
+
+# Populate the mydumper source
+DBPATH="$TEST_DIR/sf.mydump"
+RAW_PATH="${DBPATH}_tmp"
+
+mkdir -p $DBPATH $TEST_DIR/sf.mydump_tmp
+DB=linkfiles
+
+ROW_COUNT=1000
+
+echo "CREATE DATABASE $DB;" > "$RAW_PATH/ch-schema-create.sql"
+echo "CREATE TABLE t(s varchar(64), i INT, j TINYINT,  PRIMARY KEY(s, i));" > "$RAW_PATH/$DB.t-schema.sql"
+echo "CREATE TABLE t2(i INT PRIMARY KEY, s varchar(32))" > "$RAW_PATH/$DB.t2-schema.sql"
+
+echo "s,i,j" > "$RAW_PATH/$DB.t.0.sql"
+for i in $(seq "$ROW_COUNT"); do
+    echo "\"thisisastringvalues_line$i\",$i,$i" >> "$RAW_PATH/$DB.t.0.sql"
+done
+
+echo "i,s" > "$RAW_PATH/$DB.t.0.sql"
+for i in $(seq $ROW_COUNT); do
+  echo "$i,\"test123ataettaet$i\"" >> "$RAW_PATH/$DB.t2.0.sql"
+done
+
+# link source files to source dir
+ls $RAW_PATH | xargs -I{} ln -s $RAW_PATH/{} $DBPATH/{}
+
+# Start importing the tables.
+run_sql "DROP DATABASE IF EXISTS $DB"
+
+run_lightning -d "$DBPATH" --backend local 2> /dev/null
+run_sql "SELECT count(*) FROM $DB.t"
+check_contains "count(*): $ROW_COUNT"
+
+run_sql "SELECT count(*) FROM $DB.t2"
+check_contains "count(*): $ROW_COUNT"


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-Lightning! Please read the [CONTRIBUTING](https://github.com/pingcap/tidb-lightning/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
- update to newest br to fix WalkDir bug for soft link files, see: https://github.com/pingcap/br/pull/492
- Also move task checkpoint table to the backup db when backup checkpoint db

### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

Side effects

Related changes
