### PR TITLE
checkpoint: fix chunk checkpoint may reset offset and row id

### DIFF
--- a/lightning/restore/restore.go
+++ b/lightning/restore/restore.go
@@ -1714,9 +1714,12 @@ func (cr *chunkRestore) deliverLoop(
 
 	for !channelClosed {
 		var dataChecksum, indexChecksum verify.KVChecksum
-		var offset, rowID int64
 		var columns []string
 		var kvPacket []deliveredKVs
+		// init these two field as checkpoint current value, so even if there are no kv pairs delivered,
+		// chunk checkpoint should stay the same
+		offset := cr.chunk.Chunk.Offset
+		rowID := cr.chunk.Chunk.PrevRowIDMax
 		// Fetch enough KV pairs from the source.
 	populate:
 		for dataChecksum.SumSize()+indexChecksum.SumSize() < minDeliverBytes {


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-Lightning! Please read the [CONTRIBUTING](https://github.com/pingcap/tidb-lightning/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Fix chunk checkpoint `row_id` and `offset` maybe occasionally reset if chunk remain rows are empty.

Giving a sql source file: 
```
insert into a values (2);
```
And It's initial chunk checkpoint:
```
Chunk{Offset:0, EndOffset: 25, PrevRowIDMax: 8, RowIDMax:16}
```
After read the only first row, the checkpoint will be updated to:
```
Chunk{Offset:24, EndOffset: 25, PrevRowIDMax: 9, RowIDMax:16}
```
If lightning exit at this point and restart with checkpoint, then since this check offset < EndOffset , lightning will restore this chunk again, but there is no more row, so the checkpoint will be update as:
```
Chunk{Offset:0, EndOffset: 25, PrevRowIDMax: 0, RowIDMax:16}
```
By the current logic: https://github.com/pingcap/tidb-lightning/blob/6e39bb857e2d728c2eb676fbf4739d1f83b6a94d/lightning/restore/restore.go#L1717-L1770, which is obvious incorrent.

NOTE: this bug can cause some integration test fails occasionally. See: https://internal.pingcap.net/idc-jenkins/blue/organizations/jenkins/lightning_ghpr_test/detail/lightning_ghpr_test/1770/pipeline/

### What is changed and how it works?
Init the `row_id` and `offset` with the checkpoint previous values, so if there is no more rows, the fields won't be reset to default value.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

Side effects

Related changes
