### PR TITLE
test: make start tiflash optional in integration test

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -11,7 +11,7 @@ programs.
     * `bin/tikv-server`
     * `bin/tidb-server`
     * `bin/tikv-importer`
-    * `bin/tiflash`
+    * `bin/tiflash` (needed if environment variable TIFLASH=1 is set)
     * `bin/minio`
 
     The versions must be ≥2.1.0 as usual.
@@ -34,6 +34,7 @@ Run `make integration_test` to execute the integration tests. This command will
 1. Check that all 4 executables exist.
 2. Build a `tidb-lightning` executable for collecting code coverage with failpoint support
 3. Execute `tests/run.sh`
+4. to start cluster with tiflash, please run `TIFLASH=1 tests/run.sh`
 
 If the first two steps are done before, you could also run `tests/run.sh` directly.
 This script will

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -72,6 +72,9 @@ filename = "$TEST_DIR/pd.log"
 enable-placement-rules = true
 max-replicas = 1
 
+[schedule]
+low-space-ratio = 0.99
+
 [security]
 cacert-path = "$TT/ca.pem"
 cert-path = "$TT/pd.pem"
@@ -187,6 +190,7 @@ mark_cache_size = 5368709120
 path = "$TEST_DIR/tiflash/data"
 tcp_port_secure = 9002
 tmp_path = "/tmp/tiflash"
+capacity = "10737418240"
 
 [application]
 runAsDaemon = true

--- a/tests/tiflash/run.sh
+++ b/tests/tiflash/run.sh
@@ -13,13 +13,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-check_cluster_version 3 1 0 'TiFlash' || exit 0
+# fi cluster version < v3.1.0 || $TIFLASH is not set, skip this test
+(check_cluster_version 3 1 0 'TiFlash' && [ -n "$TIFLASH" ]) || exit 0
 
 set -euE
-
 # Populate the mydumper source
 DBPATH="$TEST_DIR/tiflash.mydump"
-
 mkdir -p $DBPATH
 DB=test_tiflash
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-Lightning! Please read the [CONTRIBUTING](https://github.com/pingcap/tidb-lightning/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Make TiFlash optional, so we can avoid trying to start tiflash with v3.0.0 tidb cluster
After this change, we need to add `TIFLASH=1` environment when run with v3.1 or upper cluster

### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

Side effects

Related changes
