### PR TITLE
backend/local: do not retry epochNotMatch error when ingest sst

### DIFF
--- a/lightning/backend/local.go
+++ b/lightning/backend/local.go
@@ -1175,6 +1175,8 @@ func (local *local) isIngestRetryable(
 	return false, nil, errors.Errorf("non-retryable error: %s", resp.GetError().GetMessage())
 }
 
+// return the smallest []byte that is bigger than current bytes.
+// special case when key is empty, empty bytes means infinity in our context, so directly return itself.
 func nextKey(key []byte) []byte {
 	if len(key) == 0 {
 		return []byte{}

--- a/lightning/backend/local.go
+++ b/lightning/backend/local.go
@@ -1240,7 +1240,7 @@ func (local *local) isIngestRetryable(
 			}
 		}
 		return true, newRegion, errors.Errorf("not leader: %s", errPb.GetMessage())
-	case strings.Contains(errPb.Message, "Raft raft: proposal dropped"):
+	case strings.Contains(errPb.Message, "raft: proposal dropped"):
 		// TODO: we should change 'Raft raft: proposal dropped' to a error type like 'NotLeader'
 		newRegion, err = getRegion()
 		if err != nil {

--- a/lightning/backend/local.go
+++ b/lightning/backend/local.go
@@ -1180,15 +1180,8 @@ func nextKey(key []byte) []byte {
 		return []byte{}
 	}
 	res := make([]byte, 0, len(key)+1)
-	pos := 0
-	for i := len(key) - 1; i >= 0; i-- {
-		if key[i] != '\xff' {
-			pos = i
-			break
-		}
-	}
-	s, e := key[:pos], key[pos]+1
-	res = append(append(res, s...), e)
+	res = append(res, key...)
+	res = append(res, 0)
 	return res
 }
 

--- a/lightning/backend/local.go
+++ b/lightning/backend/local.go
@@ -1220,7 +1220,11 @@ func (local *local) isIngestRetryable(
 			}
 			log.L().Warn("get region by key return nil, will retry", zap.Reflect("region", region),
 				zap.Int("retry", i))
-			time.Sleep(time.Second)
+			select {
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			case <-time.After(time.Second):
+			}
 		}
 	}
 

--- a/lightning/backend/local_test.go
+++ b/lightning/backend/local_test.go
@@ -1,0 +1,33 @@
+package backend
+
+import (
+	"bytes"
+
+	. "github.com/pingcap/check"
+)
+
+type localSuite struct{}
+
+var _ = Suite(&localSuite{})
+
+func (s *localSuite) TestNextKey(c *C) {
+	c.Assert(nextKey([]byte{}), DeepEquals, []byte{})
+
+	cases := [][]byte{
+		[]byte{0},
+		[]byte{255},
+		[]byte{1, 255},
+	}
+	for _, b := range cases {
+		next := nextKey(b)
+		c.Assert(next, DeepEquals, append(b, 0))
+	}
+
+	// in the old logic, this should return []byte{} which is not the actually smallest eky
+	next := nextKey([]byte{1, 255})
+	c.Assert(bytes.Compare(next, []byte{2}), Equals, -1)
+
+	// another test case, nextkey()'s return should be smaller than key with a prefix of the origin key
+	next = nextKey([]byte{1, 255})
+	c.Assert(bytes.Compare(next, []byte{1, 255, 0, 1, 2}), Equals, -1)
+}

--- a/lightning/backend/local_test.go
+++ b/lightning/backend/local_test.go
@@ -14,9 +14,9 @@ func (s *localSuite) TestNextKey(c *C) {
 	c.Assert(nextKey([]byte{}), DeepEquals, []byte{})
 
 	cases := [][]byte{
-		[]byte{0},
-		[]byte{255},
-		[]byte{1, 255},
+		{0},
+		{255},
+		{1, 255},
 	}
 	for _, b := range cases {
 		next := nextKey(b)


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-Lightning! Please read the [CONTRIBUTING](https://github.com/pingcap/tidb-lightning/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
- add retry for `SplitAndScatterRegionByRanges` since it may caused by region leader changes
- do not directly retry ingest if the return error is `EpochNotMatch` because tikv will check the epoch in SstMeta and the newest Region info, but we can change the epoch in SstMeta 
- retry ingest if the error is `Raft raft: proposal dropped`, because this means there is a leader transfer for this region
- downgrade some log level from Error to Warn, since they are retryable
- fix a bug in backend/log that cause scan region by range return one more region that does not intersect with the range  if the range end key is prefix of the region start key

### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

Side effects

Related changes

Release Note
- fix several trivial bugs when ingesting sst files in local backend