### PR TITLE
test: fix a unstable integration test

### DIFF
--- a/tests/_utils/run_services
+++ b/tests/_utils/run_services
@@ -5,7 +5,7 @@ stop_services() {
     killall -9 tikv-importer || true
     killall -9 tiflash || true
 
-    find "$TEST_DIR" -maxdepth 1 -not -path "$TEST_DIR" -not -name "cov.*" -not -name "*.log" | xargs rm -r || true
+    find "$TEST_DIR" -maxdepth 1 -not -path "$TEST_DIR" -not -name "cov.*" -not -name "*.log" | xargs rm -rf || true
 }
 
 start_services() {

--- a/tests/row-format-v2/run.sh
+++ b/tests/row-format-v2/run.sh
@@ -5,7 +5,12 @@
 
 set -eux
 
+run_sql 'show variables like "%tidb_row_format_version%";'
+row_format=$(grep 'Value: [0-9]' "$TEST_DIR/sql_res.$TEST_NAME.txt" | awk '{print $2}')
+
+if [ "$row_format" -ne "2" ]; then
 run_sql 'SET @@global.tidb_row_format_version = 2;' || { echo 'TiDB does not support changing row format version! skipping test'; exit 0; }
+fi
 
 run_sql 'DROP DATABASE IF EXISTS rowformatv2;'
 
@@ -18,4 +23,6 @@ run_sql 'SELECT DISTINCT col14 FROM rowformatv2.t1;'
 check_contains 'col14: NULL'
 check_contains 'col14: 39'
 
-run_sql 'SET @@global.tidb_row_format_version = 1;'
+if [ "$row_format" -ne "2" ]; then
+run_sql "SET @@global.tidb_row_format_version = $row_format;"
+fi


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-Lightning! Please read the [CONTRIBUTING](https://github.com/pingcap/tidb-lightning/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
When investigating the test failure in #420, I found if we run 'new_collation row-format-v2 various_types' these three tests together, the last test will fail stably. 

### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
- manual test (run TEST_NAME='new_collation row-format-v2 various_types' tests/run.sh)

Side effects

Related changes
