### PR TITLE
config: support encode PostOpLevel and Duration as input

### DIFF
--- a/lightning/config/config.go
+++ b/lightning/config/config.go
@@ -145,6 +145,12 @@ func (t *PostOpLevel) UnmarshalTOML(v interface{}) error {
 		}
 	case string:
 		return t.FromStringValue(val)
+	case int64:
+		if int64(OpLevelOff) <= val && val <= int64(OpLevelRequired) {
+			*t = PostOpLevel(val)
+		} else {
+			return errors.Errorf("invalid op level '%v', please choose valid option between ['off', 'optional', 'required']", v)
+		}
 	default:
 		return errors.Errorf("invalid op level '%v', please choose valid option between ['off', 'optional', 'required']", v)
 	}

--- a/lightning/config/config.go
+++ b/lightning/config/config.go
@@ -145,16 +145,14 @@ func (t *PostOpLevel) UnmarshalTOML(v interface{}) error {
 		}
 	case string:
 		return t.FromStringValue(val)
-	case int64:
-		if int64(OpLevelOff) <= val && val <= int64(OpLevelRequired) {
-			*t = PostOpLevel(val)
-		} else {
-			return errors.Errorf("invalid op level '%v', please choose valid option between ['off', 'optional', 'required']", v)
-		}
 	default:
 		return errors.Errorf("invalid op level '%v', please choose valid option between ['off', 'optional', 'required']", v)
 	}
 	return nil
+}
+
+func (t PostOpLevel) MarshalText() ([]byte, error) {
+	return []byte(t.String()), nil
 }
 
 // parser command line parameter
@@ -296,6 +294,10 @@ func (d *Duration) UnmarshalText(text []byte) error {
 	var err error
 	d.Duration, err = time.ParseDuration(string(text))
 	return err
+}
+
+func (d Duration) MarshalText() ([]byte, error) {
+	return []byte(d.String()), nil
 }
 
 func (d *Duration) MarshalJSON() ([]byte, error) {

--- a/lightning/config/config_test.go
+++ b/lightning/config/config_test.go
@@ -572,12 +572,22 @@ func (s *configTestSuite) TestTomlPostRestore(c *C) {
 		err := cfg.LoadFromTOML([]byte(confStr))
 		c.Assert(err, IsNil)
 		c.Assert(cfg.PostRestore.Checksum, Equals, v)
+
+		confStr = fmt.Sprintf("[post-restore]\r\nchecksum= %v\r\n", int(v))
+		err = cfg.LoadFromTOML([]byte(confStr))
+		c.Assert(err, IsNil)
+		c.Assert(cfg.PostRestore.Checksum, Equals, v)
 	}
 
 	for k, v := range kvMap {
 		cfg := &config.Config{}
 		confStr := fmt.Sprintf("[post-restore]\r\nanalyze= %s\r\n", k)
 		err := cfg.LoadFromTOML([]byte(confStr))
+		c.Assert(err, IsNil)
+		c.Assert(cfg.PostRestore.Analyze, Equals, v)
+
+		confStr = fmt.Sprintf("[post-restore]\r\nanalyze= %v\r\n", int(v))
+		err = cfg.LoadFromTOML([]byte(confStr))
 		c.Assert(err, IsNil)
 		c.Assert(cfg.PostRestore.Analyze, Equals, v)
 	}

--- a/lightning/config/config_test.go
+++ b/lightning/config/config_test.go
@@ -24,7 +24,6 @@ import (
 	"path/filepath"
 	"regexp"
 	"strconv"
-	"strings"
 	"testing"
 	"time"
 
@@ -582,7 +581,7 @@ func (s *configTestSuite) TestTomlPostRestore(c *C) {
 
 		b.Reset()
 		c.Assert(enc.Encode(cfg.PostRestore), IsNil)
-		c.Assert(b, Matches, fmt.Sprintf(`.*checksum = "\Q%s\E".*`, v))
+		c.Assert(&b, Matches, fmt.Sprintf(`(?s).*checksum = "\Q%s\E".*`, v))
 	}
 
 	for k, v := range kvMap {
@@ -594,7 +593,7 @@ func (s *configTestSuite) TestTomlPostRestore(c *C) {
 
 		b.Reset()
 		c.Assert(enc.Encode(cfg.PostRestore), IsNil)
-		c.Assert(strings.Contains(b.String(), fmt.Sprintf(`analyze = "%s"`, v.String())), IsTrue)
+		c.Assert(&b, Matches, fmt.Sprintf(`(?s).*analyze = "\Q%s\E".*`, v))
 	}
 }
 

--- a/lightning/config/config_test.go
+++ b/lightning/config/config_test.go
@@ -582,7 +582,7 @@ func (s *configTestSuite) TestTomlPostRestore(c *C) {
 
 		b.Reset()
 		c.Assert(enc.Encode(cfg.PostRestore), IsNil)
-		c.Assert(strings.Contains(b.String(), fmt.Sprintf(`checksum = "%s"`, v.String())), IsTrue)
+		c.Assert(b, Matches, fmt.Sprintf(`.*checksum = "\Q%s\E".*`, v))
 	}
 
 	for k, v := range kvMap {


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-Lightning! Please read the [CONTRIBUTING](https://github.com/pingcap/tidb-lightning/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
currently in lightning via SQL, task config is encoded to string and write to `GlobalConfig.ConfigFileContent`. (I'll add a better interface later). `PostOpLevel` and `Duration` are different from their input format after encoding.

### What is changed and how it works?
add `MarshalText` to these struct

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Side effects

Related changes
