### PR TITLE
dep: update uuid dependency to latest google/uuid

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -132,6 +132,11 @@ update:
 	GO111MODULE=on go mod tidy
 	$(FINISH_MOD)
 
+manual_update:
+	GO111MODULE=on go mod verify
+	GO111MODULE=on go mod tidy
+	$(FINISH_MOD)
+
 $(FAILPOINT_CTL_BIN):
 	cd tools && $(GOBUILD) -o ../$(FAILPOINT_CTL_BIN) github.com/pingcap/failpoint/failpoint-ctl
 

--- a/cmd/tidb-lightning-ctl/main.go
+++ b/cmd/tidb-lightning-ctl/main.go
@@ -24,7 +24,7 @@ import (
 
 	"github.com/pingcap/errors"
 	"github.com/pingcap/kvproto/pkg/import_sstpb"
-	uuid "github.com/google/uuid"
+	"github.com/google/uuid"
 
 	kv "github.com/pingcap/tidb-lightning/lightning/backend"
 	"github.com/pingcap/tidb-lightning/lightning/common"
@@ -311,10 +311,8 @@ func unsafeCloseEngine(ctx context.Context, importer kv.Backend, engine string) 
 		return ce, errors.Trace(err)
 	}
 
-	engineUUID, err := uuid.FromString(engine)
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
+	engineUUID := uuid.UUID{}
+	_ = engineUUID.UnmarshalText([]byte(engine))
 
 	ce, err := importer.UnsafeCloseEngineWithUUID(ctx, "<tidb-lightning-ctl>", engineUUID)
 	return ce, errors.Trace(err)

--- a/cmd/tidb-lightning-ctl/main.go
+++ b/cmd/tidb-lightning-ctl/main.go
@@ -312,7 +312,10 @@ func unsafeCloseEngine(ctx context.Context, importer kv.Backend, engine string) 
 	}
 
 	engineUUID := uuid.UUID{}
-	_ = engineUUID.UnmarshalText([]byte(engine))
+	err := engineUUID.UnmarshalText([]byte(engine))
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
 
 	ce, err := importer.UnsafeCloseEngineWithUUID(ctx, "<tidb-lightning-ctl>", engineUUID)
 	return ce, errors.Trace(err)

--- a/cmd/tidb-lightning-ctl/main.go
+++ b/cmd/tidb-lightning-ctl/main.go
@@ -311,8 +311,7 @@ func unsafeCloseEngine(ctx context.Context, importer kv.Backend, engine string) 
 		return ce, errors.Trace(err)
 	}
 
-	engineUUID := uuid.UUID{}
-	err := engineUUID.UnmarshalText([]byte(engine))
+	engineUUID, err := uuid.Parse(engine)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/cmd/tidb-lightning-ctl/main.go
+++ b/cmd/tidb-lightning-ctl/main.go
@@ -24,7 +24,7 @@ import (
 
 	"github.com/pingcap/errors"
 	"github.com/pingcap/kvproto/pkg/import_sstpb"
-	uuid "github.com/satori/go.uuid"
+	uuid "github.com/google/uuid"
 
 	kv "github.com/pingcap/tidb-lightning/lightning/backend"
 	"github.com/pingcap/tidb-lightning/lightning/common"

--- a/go.mod1
+++ b/go.mod1
@@ -15,6 +15,7 @@ require (
 	github.com/gogo/protobuf v1.3.1
 	github.com/golang/mock v1.4.4
 	github.com/google/go-cmp v0.5.0 // indirect
+	github.com/google/uuid v1.1.1
 	github.com/joho/sqltocsv v0.0.0-20190824231449-5650f27fd5b6
 	github.com/juju/loggo v0.0.0-20180524022052-584905176618 // indirect
 	github.com/onsi/ginkgo v1.13.0 // indirect
@@ -29,7 +30,6 @@ require (
 	github.com/pingcap/tidb-tools v4.0.5-0.20200820092506-34ea90c93237+incompatible
 	github.com/prometheus/client_golang v1.5.1
 	github.com/prometheus/client_model v0.2.0
-	github.com/satori/go.uuid v1.2.1-0.20181028125025-b2ce2384e17b
 	github.com/shurcooL/httpgzip v0.0.0-20190720172056-320755c1c1b0
 	github.com/spaolacci/murmur3 v1.1.0 // indirect
 	github.com/tikv/pd v1.1.0-beta.0.20200910042021-254d1345be09

--- a/go.mod1
+++ b/go.mod1
@@ -29,7 +29,7 @@ require (
 	github.com/pingcap/tidb-tools v4.0.5-0.20200820092506-34ea90c93237+incompatible
 	github.com/prometheus/client_golang v1.5.1
 	github.com/prometheus/client_model v0.2.0
-	github.com/satori/go.uuid v1.2.0
+	github.com/satori/go.uuid v1.2.1-0.20181028125025-b2ce2384e17b
 	github.com/shurcooL/httpgzip v0.0.0-20190720172056-320755c1c1b0
 	github.com/spaolacci/murmur3 v1.1.0 // indirect
 	github.com/tikv/pd v1.1.0-beta.0.20200910042021-254d1345be09

--- a/go.sum1
+++ b/go.sum1
@@ -51,8 +51,10 @@ github.com/VividCortex/ewma v1.1.1 h1:MnEK4VOv6n0RSY4vtRe3h11qjxL3+t0B8yOL8iMXdc
 github.com/VividCortex/ewma v1.1.1/go.mod h1:2Tkkvm3sRDVXaiyucHiACn4cqf7DpdyLvmxzcbUokwA=
 github.com/VividCortex/mysqlerr v0.0.0-20200629151747-c28746d985dd/go.mod h1:f3HiCrHjHBdcm6E83vGaXh1KomZMA2P6aeo3hKx/wg0=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
+github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751 h1:JYp7IbQjafoB+tBA3gMyHYHrpOtNuDiK/uB5uXxq5wM=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
+github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4 h1:Hs82Z41s6SdL1CELW+XaDYmOH4hkBN4/N9og/AsOv7E=
 github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/antihax/optional v0.0.0-20180407024304-ca021399b1a6/go.mod h1:V8iCPQYkqmusNa815XgQio277wI47sdRh1dUOLdyC6Q=
 github.com/apache/thrift v0.0.0-20181112125854-24918abba929 h1:ubPe2yRkS6A/X37s0TVGfuN42NV2h0BlzWj0X76RoUw=
@@ -122,6 +124,7 @@ github.com/coreos/go-systemd v0.0.0-20180511133405-39ca1b05acc7/go.mod h1:F5haX7
 github.com/coreos/go-systemd v0.0.0-20181031085051-9002847aa142/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
 github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e h1:Wf6HqHfScWJN9/ZjdUKyjop4mf3Qdd+1TvvltAvM3m8=
 github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
+github.com/coreos/go-systemd v0.0.0-20190719114852-fd7a80b32e1f h1:JOrtw2xFKzlg+cbHpyrpLDmnN1HqhBfnX7WDiW7eG2c=
 github.com/coreos/go-systemd v0.0.0-20190719114852-fd7a80b32e1f/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
 github.com/coreos/pkg v0.0.0-20160727233714-3ac0863d7acf/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
 github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f h1:lBNOc5arjvs8E5mO2tbpBpLoyyu8B6e44T7hJy6potg=
@@ -443,6 +446,7 @@ github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3Rllmb
 github.com/montanaflynn/stats v0.0.0-20151014174947-eeaced052adb h1:bsjNADsjHq0gjU7KO7zwoX5k3HtFdf6TDzB3ncl5iUs=
 github.com/montanaflynn/stats v0.0.0-20151014174947-eeaced052adb/go.mod h1:wL8QJuTMNUDYhXwkmfOly8iTdp5TEcJFWZD2D7SIkUc=
 github.com/montanaflynn/stats v0.0.0-20180911141734-db72e6cae808/go.mod h1:wL8QJuTMNUDYhXwkmfOly8iTdp5TEcJFWZD2D7SIkUc=
+github.com/montanaflynn/stats v0.5.0 h1:2EkzeTSqBB4V4bJwWrt5gIIrZmpJBcoIRGS2kWLgzmk=
 github.com/montanaflynn/stats v0.5.0/go.mod h1:wL8QJuTMNUDYhXwkmfOly8iTdp5TEcJFWZD2D7SIkUc=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/ncw/directio v1.0.4 h1:CojwI07mCEmRkajgx42Pf8jyCwTs1ji9/Ij9/PJG12k=
@@ -548,6 +552,7 @@ github.com/pingcap/failpoint v0.0.0-20200506114213-c17f16071c53 h1:8sC8OLinmaw24
 github.com/pingcap/failpoint v0.0.0-20200506114213-c17f16071c53/go.mod h1:w4PEZ5y16LeofeeGwdgZB4ddv9bLyDuIX+ljstgKZyk=
 github.com/pingcap/failpoint v0.0.0-20200603062251-b230c36c413c h1:cm0zAj+Tab94mp4OH+VoLJiSNQvZO4pWDGJ8KEk2a0c=
 github.com/pingcap/failpoint v0.0.0-20200603062251-b230c36c413c/go.mod h1:w4PEZ5y16LeofeeGwdgZB4ddv9bLyDuIX+ljstgKZyk=
+github.com/pingcap/failpoint v0.0.0-20200702092429-9f69995143ce h1:Y1kCxlCtlPTMtVcOkjUcuQKh+YrluSo7+7YMCQSzy30=
 github.com/pingcap/failpoint v0.0.0-20200702092429-9f69995143ce/go.mod h1:w4PEZ5y16LeofeeGwdgZB4ddv9bLyDuIX+ljstgKZyk=
 github.com/pingcap/fn v0.0.0-20191016082858-07623b84a47d h1:rCmRK0lCRrHMUbS99BKFYhK9YxJDNw0xB033cQbYo0s=
 github.com/pingcap/fn v0.0.0-20191016082858-07623b84a47d/go.mod h1:fMRU1BA1y+r89AxUoaAar4JjrhUkVDt0o0Np6V8XbDQ=
@@ -687,6 +692,8 @@ github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQD
 github.com/sasha-s/go-deadlock v0.2.0/go.mod h1:StQn567HiB1fF2yJ44N9au7wOhrPS3iZqiDbRupzT10=
 github.com/satori/go.uuid v1.2.0 h1:0uYX9dsZ2yD7q2RtLRtPSdGDWzjeM3TbMJP9utgA0ww=
 github.com/satori/go.uuid v1.2.0/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=
+github.com/satori/go.uuid v1.2.1-0.20181028125025-b2ce2384e17b h1:gQZ0qzfKHQIybLANtM3mBXNUtOfsCFXeTsnBqCsx1KM=
+github.com/satori/go.uuid v1.2.1-0.20181028125025-b2ce2384e17b/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=
 github.com/sclevine/agouti v3.0.0+incompatible/go.mod h1:b4WX9W9L1sfQKXeJf1mUTLZKJ48R1S7H23Ji7oFO5Bw=
 github.com/sergi/go-diff v1.0.1-0.20180205163309-da645544ed44/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=
 github.com/shirou/gopsutil v2.19.10+incompatible h1:lA4Pi29JEVIQIgATSeftHSY0rMGI9CLrl2ZvDLiahto=
@@ -743,6 +750,7 @@ github.com/swaggo/swag v1.6.6-0.20200323071853-8e21f4cefeea/go.mod h1:xDhTyuFIuj
 github.com/swaggo/swag v1.6.6-0.20200529100950-7c765ddd0476/go.mod h1:xDhTyuFIujYiN3DKWC/H/83xcfHp+UE/IzWWampG7Zc=
 github.com/syndtr/goleveldb v0.0.0-20180815032940-ae2bd5eed72d h1:4J9HCZVpvDmj2tiKGSTUnb3Ok/9CEQb9oqu9LHKQQpc=
 github.com/syndtr/goleveldb v0.0.0-20180815032940-ae2bd5eed72d/go.mod h1:Z4AUp2Km+PwemOoO/VB5AOx9XSsIItzFjoJlOSiYmn0=
+github.com/syndtr/goleveldb v1.0.1-0.20190625010220-02440ea7a285 h1:uSDYjYejelKyceA6DiCsngFof9jAyeaSyX9XC5a1a7Q=
 github.com/syndtr/goleveldb v1.0.1-0.20190625010220-02440ea7a285/go.mod h1:9OrXJhf154huy1nPWmuSrkgjPUtUNhA+Zmy+6AESzuA=
 github.com/tiancaiamao/appdash v0.0.0-20181126055449-889f96f722a2 h1:mbAskLJ0oJfDRtkanvQPiooDH8HvJ2FBh+iKT/OmiQQ=
 github.com/tiancaiamao/appdash v0.0.0-20181126055449-889f96f722a2/go.mod h1:2PfKggNGDuadAa0LElHrByyrz4JPZ9fFx6Gs7nx7ZZU=
@@ -805,6 +813,7 @@ github.com/zhangjinpeng1987/raft v0.0.0-20200819064223-df31bb68a018/go.mod h1:rT
 go.etcd.io/bbolt v1.3.2/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
 go.etcd.io/bbolt v1.3.3 h1:MUGmc65QhB3pIlaQ5bB4LwqSj6GIonVJXpZiaKNyaKk=
 go.etcd.io/bbolt v1.3.3/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
+go.etcd.io/bbolt v1.3.5 h1:XAzx9gjCb0Rxj7EoqcClPD1d5ZBxZJk0jbuoPHenBt0=
 go.etcd.io/bbolt v1.3.5/go.mod h1:G5EMThwa9y8QZGBClrRx5EY+Yw9kAhnjy3bSjsnlVTQ=
 go.etcd.io/etcd v0.0.0-20191023171146-3cf2f69b5738/go.mod h1:dnLIgRNXwCJa5e+c6mIZCrds/GIG4ncV9HhK5PX7jPg=
 go.etcd.io/etcd v0.5.0-alpha.5.0.20191023171146-3cf2f69b5738 h1:lWF4f9Nypl1ZqSb4gLeh/DGvBYVaUYHuiB93teOmwgc=
@@ -895,6 +904,7 @@ golang.org/x/mod v0.1.1-0.20191105210325-c90efee705ee/go.mod h1:QqPTAvyqsEbceGzB
 golang.org/x/mod v0.1.1-0.20191107180719-034126e5016b/go.mod h1:QqPTAvyqsEbceGzBzNggFXnrqF1CaUcvgkdR5Ot7KZg=
 golang.org/x/mod v0.2.0 h1:KU7oHjnv3XNWfa5COkzUifxZmxp1TyI7ImMXqFxLwvQ=
 golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
+golang.org/x/mod v0.3.0 h1:RM4zey1++hCTbCVQfnWeKs9/IEsaBLA8vTkd0WVtmH4=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/net v0.0.0-20180406214816-61147c48b25b/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
@@ -948,6 +958,7 @@ golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20190227155943-e225da77a7e6/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208 h1:qwRHBd0NqMbJxfbotnDhm2ByMI1Shq4Y6oRJo21SGJA=
 golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
@@ -1057,6 +1068,7 @@ golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8T
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 h1:go1bK/D/BFZV2I8cIQd1NKEZ+0owSTG1fDTci4IqFcE=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/api v0.4.0/go.mod h1:8k5glujaEP+g9n7WNsDg8QP6cUVNI86fCNMcbazEtwE=
 google.golang.org/api v0.7.0/go.mod h1:WtwebWUNSVBH/HAw79HIFXZNqEvBhG+Ra+ax0hx3E3M=
@@ -1097,6 +1109,7 @@ google.golang.org/genproto v0.0.0-20200122232147-0452cf42e150 h1:VPpdpQkGvFicX9y
 google.golang.org/genproto v0.0.0-20200122232147-0452cf42e150/go.mod h1:n3cpQtvxv34hfy77yVDNjmbRyujviMdxYliBSkLhpCc=
 google.golang.org/genproto v0.0.0-20200204135345-fa8e72b47b90/go.mod h1:GmwEX6Z4W5gMy59cAlVYjN9JhxgbQH6Gn+gFDQe2lzA=
 google.golang.org/genproto v0.0.0-20200212174721-66ed5ce911ce/go.mod h1:55QSHmfGQM9UVYDPBsyGGes0y52j32PQ3BqQfXhyH3c=
+google.golang.org/genproto v0.0.0-20200224152610-e50cd9704f63 h1:YzfoEYWbODU5Fbt37+h7X16BWQbad7Q4S6gclTKFXM8=
 google.golang.org/genproto v0.0.0-20200224152610-e50cd9704f63/go.mod h1:55QSHmfGQM9UVYDPBsyGGes0y52j32PQ3BqQfXhyH3c=
 google.golang.org/grpc v0.0.0-20180607172857-7a6a684ca69e/go.mod h1:yo6s7OP7yaDglbqo1J04qKzAhqBH6lvTonzMVmEdcZw=
 google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=
@@ -1110,6 +1123,7 @@ google.golang.org/grpc v1.25.1/go.mod h1:c3i+UQWmh7LiEpx4sFZnkU36qjEYZ0imhYfXVyQ
 google.golang.org/grpc v1.26.0 h1:2dTRdpdFEEhJYQD8EMLB61nnrzSCTbG38PhqdhvOltg=
 google.golang.org/grpc v1.26.0/go.mod h1:qbnxyOmOxrQa7FizSgH+ReBfzJrCY1pSN7KXBS8abTk=
 google.golang.org/grpc v1.27.0/go.mod h1:qbnxyOmOxrQa7FizSgH+ReBfzJrCY1pSN7KXBS8abTk=
+google.golang.org/grpc v1.27.1 h1:zvIju4sqAGvwKspUQOhwnpcqSbzi7/H6QomNNjTL4sk=
 google.golang.org/grpc v1.27.1/go.mod h1:qbnxyOmOxrQa7FizSgH+ReBfzJrCY1pSN7KXBS8abTk=
 google.golang.org/protobuf v0.0.0-20200109180630-ec00e32a8dfd/go.mod h1:DFci5gLYBciE7Vtevhsrf46CRTquxDuWsQurQQe4oz8=
 google.golang.org/protobuf v0.0.0-20200221191635-4d8936d0db64/go.mod h1:kwYJMbMJ01Woi6D6+Kah6886xMZcty6N08ah7+eCXa0=
@@ -1119,6 +1133,7 @@ google.golang.org/protobuf v1.21.0/go.mod h1:47Nbq4nVaFHyn7ilMalzfO3qCViNmqZ2kzi
 google.golang.org/protobuf v1.23.0 h1:4MY060fB1DLGMB/7MBTLnwQUY6+F09GEiz6SsrNqyzM=
 google.golang.org/protobuf v1.23.0/go.mod h1:EGpADcykh3NcUnDUJcl1+ZksZNG86OlYog2l/sGQquU=
 gopkg.in/alecthomas/gometalinter.v2 v2.0.12/go.mod h1:NDRytsqEZyolNuAgTzJkZMkSQM7FIKyzVzGhjB/qfYo=
+gopkg.in/alecthomas/kingpin.v2 v2.2.6 h1:jMFz6MfLP0/4fUyZle81rXUoxOBFi19VUFKVDOQfozc=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/alecthomas/kingpin.v3-unstable v3.0.0-20180810215634-df19058c872c/go.mod h1:3HH7i1SgMqlzxCcBmUHW657sD4Kvv9sC3HpL3YukzwA=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
@@ -1168,6 +1183,7 @@ honnef.co/go/tools v0.0.1-2019.2.3/go.mod h1:a3bituU0lyd329TUQxRnasdCoJDkEUEAqEt
 honnef.co/go/tools v0.0.1-2020.1.3/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
 honnef.co/go/tools v0.0.1-2020.1.4 h1:UoveltGrhghAA7ePc+e+QYDHXrBps2PqFZiHkGR/xK8=
 honnef.co/go/tools v0.0.1-2020.1.4/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
+honnef.co/go/tools v0.0.1-2020.1.5 h1:nI5egYTGJakVyOryqLs1cQO5dO0ksin5XXs2pspk75k=
 honnef.co/go/tools v0.0.1-2020.1.5/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
 k8s.io/klog v1.0.0/go.mod h1:4Bi6QPql/J/LkTDqv7R/cd3hPo4k2DG6Ptcz060Ez5I=
 modernc.org/mathutil v1.0.0 h1:93vKjrJopTPrtTNpZ8XIovER7iCIH1QU7wNbOQXC60I=

--- a/go.sum1
+++ b/go.sum1
@@ -692,8 +692,6 @@ github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQD
 github.com/sasha-s/go-deadlock v0.2.0/go.mod h1:StQn567HiB1fF2yJ44N9au7wOhrPS3iZqiDbRupzT10=
 github.com/satori/go.uuid v1.2.0 h1:0uYX9dsZ2yD7q2RtLRtPSdGDWzjeM3TbMJP9utgA0ww=
 github.com/satori/go.uuid v1.2.0/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=
-github.com/satori/go.uuid v1.2.1-0.20181028125025-b2ce2384e17b h1:gQZ0qzfKHQIybLANtM3mBXNUtOfsCFXeTsnBqCsx1KM=
-github.com/satori/go.uuid v1.2.1-0.20181028125025-b2ce2384e17b/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=
 github.com/sclevine/agouti v3.0.0+incompatible/go.mod h1:b4WX9W9L1sfQKXeJf1mUTLZKJ48R1S7H23Ji7oFO5Bw=
 github.com/sergi/go-diff v1.0.1-0.20180205163309-da645544ed44/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=
 github.com/shirou/gopsutil v2.19.10+incompatible h1:lA4Pi29JEVIQIgATSeftHSY0rMGI9CLrl2ZvDLiahto=

--- a/lightning/backend/backend.go
+++ b/lightning/backend/backend.go
@@ -24,7 +24,7 @@ import (
 	"github.com/pingcap/tidb/store/tikv/oracle"
 	"github.com/pingcap/tidb/table"
 	"github.com/pingcap/tidb/types"
-	uuid "github.com/google/uuid"
+	"github.com/google/uuid"
 	"go.uber.org/zap"
 
 	"github.com/pingcap/tidb-lightning/lightning/common"

--- a/lightning/backend/backend.go
+++ b/lightning/backend/backend.go
@@ -76,11 +76,11 @@ func makeLogger(tag string, engineUUID uuid.UUID) log.Logger {
 
 func MakeUUID(tableName string, engineID int32) (string, uuid.UUID) {
 	tag := makeTag(tableName, engineID)
-	engineNamespace := uuid.UUID{}
-	_ = engineNamespace.UnmarshalText([]byte("d68d6abe-c59e-45d6-ade8-e2b0ceb7bedf"))
 	engineUUID := uuid.NewSHA1(engineNamespace, []byte(tag))
 	return tag, engineUUID
 }
+
+var engineNamespace = uuid.MustParse("d68d6abe-c59e-45d6-ade8-e2b0ceb7bedf")
 
 // AbstractBackend is the abstract interface behind Backend.
 // Implementations of this interface must be goroutine safe: you can share an

--- a/lightning/backend/backend.go
+++ b/lightning/backend/backend.go
@@ -24,7 +24,7 @@ import (
 	"github.com/pingcap/tidb/store/tikv/oracle"
 	"github.com/pingcap/tidb/table"
 	"github.com/pingcap/tidb/types"
-	uuid "github.com/satori/go.uuid"
+	uuid "github.com/google/uuid"
 	"go.uber.org/zap"
 
 	"github.com/pingcap/tidb-lightning/lightning/common"
@@ -76,11 +76,11 @@ func makeLogger(tag string, engineUUID uuid.UUID) log.Logger {
 
 func MakeUUID(tableName string, engineID int32) (string, uuid.UUID) {
 	tag := makeTag(tableName, engineID)
-	engineUUID := uuid.NewV5(engineNamespace, tag)
+	engineNamespace := uuid.UUID{}
+	_ = engineNamespace.UnmarshalText([]byte("d68d6abe-c59e-45d6-ade8-e2b0ceb7bedf"))
+	engineUUID := uuid.NewSHA1(engineNamespace, []byte(tag))
 	return tag, engineUUID
 }
-
-var engineNamespace = uuid.Must(uuid.FromString("d68d6abe-c59e-45d6-ade8-e2b0ceb7bedf"))
 
 // AbstractBackend is the abstract interface behind Backend.
 // Implementations of this interface must be goroutine safe: you can share an

--- a/lightning/backend/backend_test.go
+++ b/lightning/backend/backend_test.go
@@ -8,7 +8,7 @@ import (
 	. "github.com/pingcap/check"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/parser/mysql"
-	uuid "github.com/google/uuid"
+	"github.com/google/uuid"
 
 	kv "github.com/pingcap/tidb-lightning/lightning/backend"
 	"github.com/pingcap/tidb-lightning/mock"

--- a/lightning/backend/backend_test.go
+++ b/lightning/backend/backend_test.go
@@ -40,7 +40,8 @@ func (s *backendSuite) TestOpenCloseImportCleanUpEngine(c *C) {
 	defer s.tearDownTest()
 
 	ctx := context.Background()
-	engineUUID := uuid.FromStringOrNil("902efee3-a3f9-53d4-8c82-f12fb1900cd1")
+	engineUUID := uuid.UUID{}
+	c.Assert(engineUUID.UnmarshalText([]byte("902efee3-a3f9-53d4-8c82-f12fb1900cd1")), IsNil)
 
 	openCall := s.mockBackend.EXPECT().
 		OpenEngine(ctx, engineUUID).
@@ -73,7 +74,8 @@ func (s *backendSuite) TestUnsafeCloseEngine(c *C) {
 	defer s.tearDownTest()
 
 	ctx := context.Background()
-	engineUUID := uuid.FromStringOrNil("7e3f3a3c-67ce-506d-af34-417ec138fbcb")
+	engineUUID := uuid.UUID{}
+	c.Assert(engineUUID.UnmarshalText([]byte("7e3f3a3c-67ce-506d-af34-417ec138fbcb")), IsNil)
 
 	closeCall := s.mockBackend.EXPECT().
 		CloseEngine(ctx, engineUUID).
@@ -94,7 +96,8 @@ func (s *backendSuite) TestUnsafeCloseEngineWithUUID(c *C) {
 	defer s.tearDownTest()
 
 	ctx := context.Background()
-	engineUUID := uuid.FromStringOrNil("f1240229-79e0-4d8d-bda0-a211bf493796")
+	engineUUID := uuid.UUID{}
+	c.Assert(engineUUID.UnmarshalText([]byte("f1240229-79e0-4d8d-bda0-a211bf493796")), IsNil)
 
 	closeCall := s.mockBackend.EXPECT().
 		CloseEngine(ctx, engineUUID).
@@ -115,7 +118,8 @@ func (s *backendSuite) TestWriteEngine(c *C) {
 	defer s.tearDownTest()
 
 	ctx := context.Background()
-	engineUUID := uuid.FromStringOrNil("902efee3-a3f9-53d4-8c82-f12fb1900cd1")
+	engineUUID := uuid.UUID{}
+	c.Assert(engineUUID.UnmarshalText([]byte("902efee3-a3f9-53d4-8c82-f12fb1900cd1")), IsNil)
 
 	rows0 := mock.NewMockRows(s.controller)
 	rows1 := mock.NewMockRows(s.controller)

--- a/lightning/backend/backend_test.go
+++ b/lightning/backend/backend_test.go
@@ -40,8 +40,7 @@ func (s *backendSuite) TestOpenCloseImportCleanUpEngine(c *C) {
 	defer s.tearDownTest()
 
 	ctx := context.Background()
-	engineUUID := uuid.UUID{}
-	c.Assert(engineUUID.UnmarshalText([]byte("902efee3-a3f9-53d4-8c82-f12fb1900cd1")), IsNil)
+	engineUUID := uuid.MustParse("902efee3-a3f9-53d4-8c82-f12fb1900cd1")
 
 	openCall := s.mockBackend.EXPECT().
 		OpenEngine(ctx, engineUUID).
@@ -74,8 +73,7 @@ func (s *backendSuite) TestUnsafeCloseEngine(c *C) {
 	defer s.tearDownTest()
 
 	ctx := context.Background()
-	engineUUID := uuid.UUID{}
-	c.Assert(engineUUID.UnmarshalText([]byte("7e3f3a3c-67ce-506d-af34-417ec138fbcb")), IsNil)
+	engineUUID := uuid.MustParse("7e3f3a3c-67ce-506d-af34-417ec138fbcb")
 
 	closeCall := s.mockBackend.EXPECT().
 		CloseEngine(ctx, engineUUID).
@@ -96,8 +94,7 @@ func (s *backendSuite) TestUnsafeCloseEngineWithUUID(c *C) {
 	defer s.tearDownTest()
 
 	ctx := context.Background()
-	engineUUID := uuid.UUID{}
-	c.Assert(engineUUID.UnmarshalText([]byte("f1240229-79e0-4d8d-bda0-a211bf493796")), IsNil)
+	engineUUID := uuid.MustParse("f1240229-79e0-4d8d-bda0-a211bf493796")
 
 	closeCall := s.mockBackend.EXPECT().
 		CloseEngine(ctx, engineUUID).
@@ -118,8 +115,7 @@ func (s *backendSuite) TestWriteEngine(c *C) {
 	defer s.tearDownTest()
 
 	ctx := context.Background()
-	engineUUID := uuid.UUID{}
-	c.Assert(engineUUID.UnmarshalText([]byte("902efee3-a3f9-53d4-8c82-f12fb1900cd1")), IsNil)
+	engineUUID := uuid.MustParse("902efee3-a3f9-53d4-8c82-f12fb1900cd1")
 
 	rows0 := mock.NewMockRows(s.controller)
 	rows1 := mock.NewMockRows(s.controller)

--- a/lightning/backend/backend_test.go
+++ b/lightning/backend/backend_test.go
@@ -8,7 +8,7 @@ import (
 	. "github.com/pingcap/check"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/parser/mysql"
-	uuid "github.com/satori/go.uuid"
+	uuid "github.com/google/uuid"
 
 	kv "github.com/pingcap/tidb-lightning/lightning/backend"
 	"github.com/pingcap/tidb-lightning/mock"

--- a/lightning/backend/importer.go
+++ b/lightning/backend/importer.go
@@ -25,7 +25,7 @@ import (
 	kv "github.com/pingcap/kvproto/pkg/import_kvpb"
 	"github.com/pingcap/parser/model"
 	"github.com/pingcap/tidb/table"
-	uuid "github.com/satori/go.uuid"
+	uuid "github.com/google/uuid"
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
 
@@ -118,8 +118,9 @@ func isIgnorableOpenCloseEngineError(err error) bool {
 }
 
 func (importer *importer) OpenEngine(ctx context.Context, engineUUID uuid.UUID) error {
+	u, _ := engineUUID.MarshalBinary()
 	req := &kv.OpenEngineRequest{
-		Uuid: engineUUID.Bytes(),
+		Uuid: u,
 	}
 
 	_, err := importer.cli.OpenEngine(ctx, req)
@@ -130,8 +131,9 @@ func (importer *importer) OpenEngine(ctx context.Context, engineUUID uuid.UUID) 
 }
 
 func (importer *importer) CloseEngine(ctx context.Context, engineUUID uuid.UUID) error {
+	u, _ := engineUUID.MarshalBinary()
 	req := &kv.CloseEngineRequest{
-		Uuid: engineUUID.Bytes(),
+		Uuid: u,
 	}
 
 	_, err := importer.cli.CloseEngine(ctx, req)
@@ -142,8 +144,9 @@ func (importer *importer) CloseEngine(ctx context.Context, engineUUID uuid.UUID)
 }
 
 func (importer *importer) ImportEngine(ctx context.Context, engineUUID uuid.UUID) error {
+	u, _ := engineUUID.MarshalBinary()
 	req := &kv.ImportEngineRequest{
-		Uuid:   engineUUID.Bytes(),
+		Uuid:   u,
 		PdAddr: importer.pdAddr,
 	}
 
@@ -152,8 +155,9 @@ func (importer *importer) ImportEngine(ctx context.Context, engineUUID uuid.UUID
 }
 
 func (importer *importer) CleanupEngine(ctx context.Context, engineUUID uuid.UUID) error {
+	u, _ := engineUUID.MarshalBinary()
 	req := &kv.CleanupEngineRequest{
-		Uuid: engineUUID.Bytes(),
+		Uuid: u,
 	}
 
 	_, err := importer.cli.CleanupEngine(ctx, req)
@@ -191,11 +195,12 @@ func (importer *importer) WriteRows(
 		}
 	}()
 
+	u, _ := engineUUID.MarshalBinary()
 	// Bind uuid for this write request
 	req := &kv.WriteEngineRequest{
 		Chunk: &kv.WriteEngineRequest_Head{
 			Head: &kv.WriteHead{
-				Uuid: engineUUID.Bytes(),
+				Uuid: u,
 			},
 		},
 	}

--- a/lightning/backend/importer.go
+++ b/lightning/backend/importer.go
@@ -118,9 +118,8 @@ func isIgnorableOpenCloseEngineError(err error) bool {
 }
 
 func (importer *importer) OpenEngine(ctx context.Context, engineUUID uuid.UUID) error {
-	u, _ := engineUUID.MarshalBinary()
 	req := &kv.OpenEngineRequest{
-		Uuid: u,
+		Uuid: engineUUID[:],
 	}
 
 	_, err := importer.cli.OpenEngine(ctx, req)
@@ -131,9 +130,8 @@ func (importer *importer) OpenEngine(ctx context.Context, engineUUID uuid.UUID) 
 }
 
 func (importer *importer) CloseEngine(ctx context.Context, engineUUID uuid.UUID) error {
-	u, _ := engineUUID.MarshalBinary()
 	req := &kv.CloseEngineRequest{
-		Uuid: u,
+		Uuid: engineUUID[:],
 	}
 
 	_, err := importer.cli.CloseEngine(ctx, req)
@@ -144,9 +142,8 @@ func (importer *importer) CloseEngine(ctx context.Context, engineUUID uuid.UUID)
 }
 
 func (importer *importer) ImportEngine(ctx context.Context, engineUUID uuid.UUID) error {
-	u, _ := engineUUID.MarshalBinary()
 	req := &kv.ImportEngineRequest{
-		Uuid:   u,
+		Uuid:   engineUUID[:],
 		PdAddr: importer.pdAddr,
 	}
 
@@ -155,9 +152,8 @@ func (importer *importer) ImportEngine(ctx context.Context, engineUUID uuid.UUID
 }
 
 func (importer *importer) CleanupEngine(ctx context.Context, engineUUID uuid.UUID) error {
-	u, _ := engineUUID.MarshalBinary()
 	req := &kv.CleanupEngineRequest{
-		Uuid: u,
+		Uuid: engineUUID[:],
 	}
 
 	_, err := importer.cli.CleanupEngine(ctx, req)
@@ -195,12 +191,11 @@ func (importer *importer) WriteRows(
 		}
 	}()
 
-	u, _ := engineUUID.MarshalBinary()
 	// Bind uuid for this write request
 	req := &kv.WriteEngineRequest{
 		Chunk: &kv.WriteEngineRequest_Head{
 			Head: &kv.WriteHead{
-				Uuid: u,
+				Uuid: engineUUID[:],
 			},
 		},
 	}

--- a/lightning/backend/importer.go
+++ b/lightning/backend/importer.go
@@ -25,7 +25,7 @@ import (
 	kv "github.com/pingcap/kvproto/pkg/import_kvpb"
 	"github.com/pingcap/parser/model"
 	"github.com/pingcap/tidb/table"
-	uuid "github.com/google/uuid"
+	"github.com/google/uuid"
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
 

--- a/lightning/backend/importer_test.go
+++ b/lightning/backend/importer_test.go
@@ -9,7 +9,7 @@ import (
 	. "github.com/pingcap/check"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/kvproto/pkg/import_kvpb"
-	uuid "github.com/satori/go.uuid"
+	uuid "github.com/google/uuid"
 
 	kvpb "github.com/pingcap/kvproto/pkg/import_kvpb"
 

--- a/lightning/backend/importer_test.go
+++ b/lightning/backend/importer_test.go
@@ -9,7 +9,7 @@ import (
 	. "github.com/pingcap/check"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/kvproto/pkg/import_kvpb"
-	uuid "github.com/google/uuid"
+	"github.com/google/uuid"
 
 	kvpb "github.com/pingcap/kvproto/pkg/import_kvpb"
 

--- a/lightning/backend/importer_test.go
+++ b/lightning/backend/importer_test.go
@@ -42,11 +42,8 @@ func (s *importerSuite) setUpTest(c *C) {
 	importer := kv.NewMockImporter(s.mockClient, testPDAddr)
 
 	s.ctx = context.Background()
-	engineUUID := uuid.UUID{}
-	c.Assert(engineUUID.UnmarshalText([]byte("7e3f3a3c-67ce-506d-af34-417ec138fbcb")), IsNil)
-	var err error
-	s.engineUUID, err = engineUUID.MarshalBinary()
-	c.Assert(err, IsNil)
+	engineUUID := uuid.MustParse("7e3f3a3c-67ce-506d-af34-417ec138fbcb")
+	s.engineUUID = engineUUID[:]
 	s.kvPairs = kv.MakeRowsFromKvPairs([]common.KvPair{
 		{
 			Key: []byte("k1"),
@@ -62,6 +59,7 @@ func (s *importerSuite) setUpTest(c *C) {
 		OpenEngine(s.ctx, &import_kvpb.OpenEngineRequest{Uuid: s.engineUUID}).
 		Return(nil, nil)
 
+	var err error
 	s.engine, err = importer.OpenEngine(s.ctx, "`db`.`table`", -1)
 	c.Assert(err, IsNil)
 }

--- a/lightning/backend/importer_test.go
+++ b/lightning/backend/importer_test.go
@@ -42,7 +42,11 @@ func (s *importerSuite) setUpTest(c *C) {
 	importer := kv.NewMockImporter(s.mockClient, testPDAddr)
 
 	s.ctx = context.Background()
-	s.engineUUID = uuid.FromStringOrNil("7e3f3a3c-67ce-506d-af34-417ec138fbcb").Bytes()
+	engineUUID := uuid.UUID{}
+	c.Assert(engineUUID.UnmarshalText([]byte("7e3f3a3c-67ce-506d-af34-417ec138fbcb")), IsNil)
+	var err error
+	s.engineUUID, err = engineUUID.MarshalBinary()
+	c.Assert(err, IsNil)
 	s.kvPairs = kv.MakeRowsFromKvPairs([]common.KvPair{
 		{
 			Key: []byte("k1"),
@@ -58,7 +62,6 @@ func (s *importerSuite) setUpTest(c *C) {
 		OpenEngine(s.ctx, &import_kvpb.OpenEngineRequest{Uuid: s.engineUUID}).
 		Return(nil, nil)
 
-	var err error
 	s.engine, err = importer.OpenEngine(s.ctx, "`db`.`table`", -1)
 	c.Assert(err, IsNil)
 }

--- a/lightning/backend/local.go
+++ b/lightning/backend/local.go
@@ -482,10 +482,9 @@ func (local *local) WriteToTiKV(
 	iter.Last()
 	lastKey := codec.EncodeBytes([]byte{}, iter.Key())
 
-	// will not return error in fact
-	u, _ := uuid.New().MarshalBinary()
+	u := uuid.New()
 	meta := &sst.SSTMeta{
-		Uuid:        u,
+		Uuid:        u[:],
 		RegionId:    region.Region.GetId(),
 		RegionEpoch: region.Region.GetRegionEpoch(),
 		Range: &sst.Range{

--- a/lightning/backend/local.go
+++ b/lightning/backend/local.go
@@ -30,6 +30,7 @@ import (
 
 	"github.com/cockroachdb/pebble"
 	"github.com/coreos/go-semver/semver"
+	"github.com/google/uuid"
 	split "github.com/pingcap/br/pkg/restore"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/failpoint"
@@ -41,7 +42,6 @@ import (
 	"github.com/pingcap/tidb/table"
 	"github.com/pingcap/tidb/tablecodec"
 	"github.com/pingcap/tidb/util/codec"
-	uuid "github.com/satori/go.uuid"
 	pd "github.com/tikv/pd/client"
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
@@ -482,12 +482,10 @@ func (local *local) WriteToTiKV(
 	iter.Last()
 	lastKey := codec.EncodeBytes([]byte{}, iter.Key())
 
-	u, err := uuid.NewV4()
-	if err != nil {
-		return nil, nil, err
-	}
+	// will not return error in fact
+	u, _ := uuid.New().MarshalBinary()
 	meta := &sst.SSTMeta{
-		Uuid:        u.Bytes(),
+		Uuid:        u,
 		RegionId:    region.Region.GetId(),
 		RegionEpoch: region.Region.GetRegionEpoch(),
 		Range: &sst.Range{

--- a/lightning/backend/local.go
+++ b/lightning/backend/local.go
@@ -482,8 +482,12 @@ func (local *local) WriteToTiKV(
 	iter.Last()
 	lastKey := codec.EncodeBytes([]byte{}, iter.Key())
 
+	u, err := uuid.NewV4()
+	if err != nil {
+		return nil, nil, err
+	}
 	meta := &sst.SSTMeta{
-		Uuid:        uuid.NewV4().Bytes(),
+		Uuid:        u.Bytes(),
 		RegionId:    region.Region.GetId(),
 		RegionEpoch: region.Region.GetRegionEpoch(),
 		Range: &sst.Range{

--- a/lightning/backend/tidb.go
+++ b/lightning/backend/tidb.go
@@ -28,7 +28,7 @@ import (
 	"github.com/pingcap/parser/mysql"
 	"github.com/pingcap/tidb/table"
 	"github.com/pingcap/tidb/types"
-	uuid "github.com/google/uuid"
+	"github.com/google/uuid"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 

--- a/lightning/backend/tidb.go
+++ b/lightning/backend/tidb.go
@@ -28,7 +28,7 @@ import (
 	"github.com/pingcap/parser/mysql"
 	"github.com/pingcap/tidb/table"
 	"github.com/pingcap/tidb/types"
-	uuid "github.com/satori/go.uuid"
+	uuid "github.com/google/uuid"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 

--- a/lightning/restore/restore_test.go
+++ b/lightning/restore/restore_test.go
@@ -34,7 +34,7 @@ import (
 	filter "github.com/pingcap/tidb-tools/pkg/table-filter"
 	"github.com/pingcap/tidb/ddl"
 	tmock "github.com/pingcap/tidb/util/mock"
-	uuid "github.com/google/uuid"
+	"github.com/google/uuid"
 
 	kv "github.com/pingcap/tidb-lightning/lightning/backend"
 	"github.com/pingcap/tidb-lightning/lightning/checkpoints"

--- a/lightning/restore/restore_test.go
+++ b/lightning/restore/restore_test.go
@@ -34,7 +34,7 @@ import (
 	filter "github.com/pingcap/tidb-tools/pkg/table-filter"
 	"github.com/pingcap/tidb/ddl"
 	tmock "github.com/pingcap/tidb/util/mock"
-	uuid "github.com/satori/go.uuid"
+	uuid "github.com/google/uuid"
 
 	kv "github.com/pingcap/tidb-lightning/lightning/backend"
 	"github.com/pingcap/tidb-lightning/lightning/checkpoints"

--- a/lightning/restore/restore_test.go
+++ b/lightning/restore/restore_test.go
@@ -718,7 +718,7 @@ func (s *tableRestoreSuite) TestImportKVSuccess(c *C) {
 	importer := kv.MakeBackend(mockBackend)
 
 	ctx := context.Background()
-	engineUUID, err := uuid.NewV4()
+	engineUUID, err := uuid.NewRandom()
 	c.Assert(err, IsNil)
 
 	mockBackend.EXPECT().
@@ -744,7 +744,7 @@ func (s *tableRestoreSuite) TestImportKVFailure(c *C) {
 	importer := kv.MakeBackend(mockBackend)
 
 	ctx := context.Background()
-	engineUUID, err := uuid.NewV4()
+	engineUUID, err := uuid.NewRandom()
 	c.Assert(err, IsNil)
 
 	mockBackend.EXPECT().

--- a/lightning/restore/restore_test.go
+++ b/lightning/restore/restore_test.go
@@ -718,8 +718,7 @@ func (s *tableRestoreSuite) TestImportKVSuccess(c *C) {
 	importer := kv.MakeBackend(mockBackend)
 
 	ctx := context.Background()
-	engineUUID, err := uuid.NewRandom()
-	c.Assert(err, IsNil)
+	engineUUID := uuid.New()
 
 	mockBackend.EXPECT().
 		CloseEngine(ctx, engineUUID).
@@ -744,8 +743,7 @@ func (s *tableRestoreSuite) TestImportKVFailure(c *C) {
 	importer := kv.MakeBackend(mockBackend)
 
 	ctx := context.Background()
-	engineUUID, err := uuid.NewRandom()
-	c.Assert(err, IsNil)
+	engineUUID := uuid.New()
 
 	mockBackend.EXPECT().
 		CloseEngine(ctx, engineUUID).

--- a/lightning/restore/restore_test.go
+++ b/lightning/restore/restore_test.go
@@ -718,7 +718,8 @@ func (s *tableRestoreSuite) TestImportKVSuccess(c *C) {
 	importer := kv.MakeBackend(mockBackend)
 
 	ctx := context.Background()
-	engineUUID := uuid.NewV4()
+	engineUUID, err := uuid.NewV4()
+	c.Assert(err, IsNil)
 
 	mockBackend.EXPECT().
 		CloseEngine(ctx, engineUUID).
@@ -743,7 +744,8 @@ func (s *tableRestoreSuite) TestImportKVFailure(c *C) {
 	importer := kv.MakeBackend(mockBackend)
 
 	ctx := context.Background()
-	engineUUID := uuid.NewV4()
+	engineUUID, err := uuid.NewV4()
+	c.Assert(err, IsNil)
 
 	mockBackend.EXPECT().
 		CloseEngine(ctx, engineUUID).

--- a/mock/backend.go
+++ b/mock/backend.go
@@ -15,7 +15,7 @@ import (
 	model "github.com/pingcap/parser/model"
 	table "github.com/pingcap/tidb/table"
 	types "github.com/pingcap/tidb/types"
-	uuid "github.com/satori/go.uuid"
+	uuid "github.com/google/uuid"
 
 	backend "github.com/pingcap/tidb-lightning/lightning/backend"
 	log "github.com/pingcap/tidb-lightning/lightning/log"

--- a/mock/backend.go
+++ b/mock/backend.go
@@ -15,7 +15,7 @@ import (
 	model "github.com/pingcap/parser/model"
 	table "github.com/pingcap/tidb/table"
 	types "github.com/pingcap/tidb/types"
-	uuid "github.com/google/uuid"
+	"github.com/google/uuid"
 
 	backend "github.com/pingcap/tidb-lightning/lightning/backend"
 	log "github.com/pingcap/tidb-lightning/lightning/log"

--- a/tools/go.sum
+++ b/tools/go.sum
@@ -203,6 +203,7 @@ github.com/pingcap/check v0.0.0-20190102082844-67f458068fc8 h1:USx2/E1bX46VG32FI
 github.com/pingcap/check v0.0.0-20190102082844-67f458068fc8/go.mod h1:B1+S9LNcuMyLH/4HMTViQOJevkGiik3wW2AN9zb2fNQ=
 github.com/pingcap/errors v0.11.4 h1:lFuQV/oaUMGcD2tqt+01ROSmJs75VG1ToEOkZIZ4nE4=
 github.com/pingcap/errors v0.11.4/go.mod h1:Oi8TUi2kEtXXLMJk9l1cGmz20kV3TaQ0usTwv5KuLY8=
+github.com/pingcap/failpoint v0.0.0-20200702092429-9f69995143ce h1:Y1kCxlCtlPTMtVcOkjUcuQKh+YrluSo7+7YMCQSzy30=
 github.com/pingcap/failpoint v0.0.0-20200702092429-9f69995143ce/go.mod h1:w4PEZ5y16LeofeeGwdgZB4ddv9bLyDuIX+ljstgKZyk=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-Lightning! Please read the [CONTRIBUTING](https://github.com/pingcap/tidb-lightning/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
after hiding lighting's go.mod and embedded it into tidb, an error checkpoint tool will raise error like

```
$ ./tools/check/check-errdoc.sh
Generate errors.toml failed: exit status 2, output:
# github.com/pingcap/tidb-lightning/lightning/backend
../../../../pkg/mod/github.com/pingcap/tidb-lightning@v4.0.9-0.20201104053247-8013216a3446+incompatible/lightning/backend/local.go:486:26: multiple-value uuid.NewV4() in single-value context
```

### What is changed and how it works?
update satori/go.uuid to latest

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - pass original test

Side effects


Related changes
