### PR TITLE
tidb-lightning-ctl: change default of -d to 'noop://'

### DIFF
--- a/cmd/tidb-lightning-ctl/main.go
+++ b/cmd/tidb-lightning-ctl/main.go
@@ -49,6 +49,13 @@ func run() error {
 	)
 
 	globalCfg := config.Must(config.LoadGlobalConfig(os.Args[1:], func(fs *flag.FlagSet) {
+		// change the default of `-d` from empty to 'noop://'.
+		// there is a check if `-d` points to a valid storage, and '' is not.
+		// since tidb-lightning-ctl does not need `-d` we change the default to a valid but harmless value.
+		dFlag := fs.Lookup("d")
+		dFlag.Value.Set("noop://")
+		dFlag.DefValue = "noop://"
+
 		compact = fs.Bool("compact", false, "do manual compaction on the target cluster")
 		mode = fs.String("switch-mode", "", "switch tikv into import mode or normal mode, values can be ['import', 'normal']")
 		flagFetchMode = fs.Bool("fetch-mode", false, "obtain the current mode of every tikv in the cluster")

--- a/lightning/config/config.go
+++ b/lightning/config/config.go
@@ -66,7 +66,7 @@ const (
 
 var (
 	defaultConfigPaths    = []string{"tidb-lightning.toml", "conf/tidb-lightning.toml"}
-	supportedStorageTypes = []string{"file", "local", "s3"}
+	supportedStorageTypes = []string{"file", "local", "s3", "noop"}
 )
 
 type DBStore struct {


### PR DESCRIPTION


<!--
Thank you for contributing to TiDB-Lightning! Please read the [CONTRIBUTING](https://github.com/pingcap/tidb-lightning/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Since #361 there is a check if the data source actually exists. This breaks `tidb-lightning-ctl` which does not require the data source directory.

### What is changed and how it works?

Change the default `-d` in `tidb-lightning-ctl` from empty string to `noop://`. 

Also added `noop` to the supported protocol list.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)
    * --fetch-mode works without passing `-d`.

Side effects

Related changes
