### PR TITLE
*: replace context.Backend with app context

### DIFF
--- a/cmd/tidb-lightning-ctl/main.go
+++ b/cmd/tidb-lightning-ctl/main.go
@@ -71,11 +71,13 @@ func run() error {
 		fsUsage = fs.Usage
 	}))
 
+	ctx := context.Background()
+
 	cfg := config.NewConfig()
 	if err := cfg.LoadFromGlobal(globalCfg); err != nil {
 		return err
 	}
-	if err := cfg.Adjust(); err != nil {
+	if err := cfg.Adjust(ctx); err != nil {
 		return err
 	}
 
@@ -86,8 +88,6 @@ func run() error {
 	if err = cfg.TiDB.Security.RegisterMySQL(); err != nil {
 		return err
 	}
-
-	ctx := context.Background()
 
 	if *compact {
 		return errors.Trace(compactCluster(ctx, cfg, tls))

--- a/lightning/backend/backend.go
+++ b/lightning/backend/backend.go
@@ -144,7 +144,7 @@ type AbstractBackend interface {
 
 func fetchRemoteTableModelsFromTLS(ctx context.Context, tls *common.TLS, schema string) ([]*model.TableInfo, error) {
 	var tables []*model.TableInfo
-	err := tls.GetJSONWithContext(ctx, "/schema/"+schema, &tables)
+	err := tls.GetJSON(ctx, "/schema/"+schema, &tables)
 	if err != nil {
 		return nil, errors.Annotatef(err, "cannot read schema '%s' from remote", schema)
 	}

--- a/lightning/backend/backend.go
+++ b/lightning/backend/backend.go
@@ -125,7 +125,7 @@ type AbstractBackend interface {
 
 	// CheckRequirements performs the check whether the backend satisfies the
 	// version requirements
-	CheckRequirements() error
+	CheckRequirements(ctx context.Context) error
 
 	// FetchRemoteTableModels obtains the models of all tables given the schema
 	// name. The returned table info does not need to be precise if the encoder,
@@ -142,9 +142,9 @@ type AbstractBackend interface {
 	FetchRemoteTableModels(ctx context.Context, schemaName string) ([]*model.TableInfo, error)
 }
 
-func fetchRemoteTableModelsFromTLS(tls *common.TLS, schema string) ([]*model.TableInfo, error) {
+func fetchRemoteTableModelsFromTLS(ctx context.Context, tls *common.TLS, schema string) ([]*model.TableInfo, error) {
 	var tables []*model.TableInfo
-	err := tls.GetJSON("/schema/"+schema, &tables)
+	err := tls.GetJSONWithContext(ctx, "/schema/"+schema, &tables)
 	if err != nil {
 		return nil, errors.Annotatef(err, "cannot read schema '%s' from remote", schema)
 	}
@@ -204,8 +204,8 @@ func (be Backend) ShouldPostProcess() bool {
 	return be.abstract.ShouldPostProcess()
 }
 
-func (be Backend) CheckRequirements() error {
-	return be.abstract.CheckRequirements()
+func (be Backend) CheckRequirements(ctx context.Context) error {
+	return be.abstract.CheckRequirements(ctx)
 }
 
 func (be Backend) FetchRemoteTableModels(ctx context.Context, schemaName string) ([]*model.TableInfo, error) {

--- a/lightning/backend/checkreq_test.go
+++ b/lightning/backend/checkreq_test.go
@@ -14,6 +14,7 @@
 package backend
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -40,6 +41,7 @@ func (s *checkReqSuite) TestCheckVersion(c *C) {
 
 func (s *checkReqSuite) TestCheckTiDBVersion(c *C) {
 	var version string
+	ctx := context.Background()
 
 	mockServer := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		c.Assert(req.URL.Path, Equals, "/status")
@@ -53,14 +55,15 @@ func (s *checkReqSuite) TestCheckTiDBVersion(c *C) {
 	tls := common.NewTLSFromMockServer(mockServer)
 
 	version = "5.7.25-TiDB-v9999.0.0"
-	c.Assert(checkTiDBVersion(tls, requiredTiDBVersion), IsNil)
+	c.Assert(checkTiDBVersion(ctx, tls, requiredTiDBVersion), IsNil)
 
 	version = "5.7.25-TiDB-v1.0.0"
-	c.Assert(checkTiDBVersion(tls, requiredTiDBVersion), ErrorMatches, "TiDB version too old.*")
+	c.Assert(checkTiDBVersion(ctx, tls, requiredTiDBVersion), ErrorMatches, "TiDB version too old.*")
 }
 
 func (s *checkReqSuite) TestCheckPDVersion(c *C) {
 	var version string
+	ctx := context.Background()
 
 	mockServer := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		c.Assert(req.URL.Path, Equals, "/pd/api/v1/config/cluster-version")
@@ -74,14 +77,15 @@ func (s *checkReqSuite) TestCheckPDVersion(c *C) {
 	tls := common.NewTLSFromMockServer(mockServer)
 
 	version = "9999.0.0"
-	c.Assert(checkPDVersion(tls, mockURL.Host, requiredPDVersion), IsNil)
+	c.Assert(checkPDVersion(ctx, tls, mockURL.Host, requiredPDVersion), IsNil)
 
 	version = "1.0.0"
-	c.Assert(checkPDVersion(tls, mockURL.Host, requiredPDVersion), ErrorMatches, "PD version too old.*")
+	c.Assert(checkPDVersion(ctx, tls, mockURL.Host, requiredPDVersion), ErrorMatches, "PD version too old.*")
 }
 
 func (s *checkReqSuite) TestCheckTiKVVersion(c *C) {
 	var versions []string
+	ctx := context.Background()
 
 	mockServer := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		c.Assert(req.URL.Path, Equals, "/pd/api/v1/stores")
@@ -108,11 +112,11 @@ func (s *checkReqSuite) TestCheckTiKVVersion(c *C) {
 	tls := common.NewTLSFromMockServer(mockServer)
 
 	versions = []string{"9999.0.0", "9999.0.0"}
-	c.Assert(checkTiKVVersion(tls, mockURL.Host, requiredTiKVVersion), IsNil)
+	c.Assert(checkTiKVVersion(ctx, tls, mockURL.Host, requiredTiKVVersion), IsNil)
 
 	versions = []string{"4.1.0", "v4.1.0-alpha-9-ga27a7dd"}
-	c.Assert(checkTiKVVersion(tls, mockURL.Host, requiredTiKVVersion), IsNil)
+	c.Assert(checkTiKVVersion(ctx, tls, mockURL.Host, requiredTiKVVersion), IsNil)
 
 	versions = []string{"9999.0.0", "1.0.0"}
-	c.Assert(checkTiKVVersion(tls, mockURL.Host, requiredTiKVVersion), ErrorMatches, `TiKV \(at tikv1\.test:20160\) version too old.*`)
+	c.Assert(checkTiKVVersion(ctx, tls, mockURL.Host, requiredTiKVVersion), ErrorMatches, `TiKV \(at tikv1\.test:20160\) version too old.*`)
 }

--- a/lightning/backend/importer.go
+++ b/lightning/backend/importer.go
@@ -255,7 +255,7 @@ func (importer *importer) CheckRequirements(ctx context.Context) error {
 
 func checkTiDBVersion(ctx context.Context, tls *common.TLS, requiredVersion semver.Version) error {
 	var status struct{ Version string }
-	err := tls.GetJSONWithContext(ctx, "/status", &status)
+	err := tls.GetJSON(ctx, "/status", &status)
 	if err != nil {
 		return err
 	}

--- a/lightning/backend/local.go
+++ b/lightning/backend/local.go
@@ -249,7 +249,7 @@ func NewLocalBackend(
 	sendKVPairs int,
 	enableCheckpoint bool,
 ) (Backend, error) {
-	pdCli, err := pd.NewClient([]string{pdAddr}, tls.ToPDSecurityOption())
+	pdCli, err := pd.NewClientWithContext(ctx, []string{pdAddr}, tls.ToPDSecurityOption())
 	if err != nil {
 		return MakeBackend(nil), errors.Annotate(err, "construct pd client failed")
 	}
@@ -1169,21 +1169,21 @@ func (local *local) CleanupEngine(ctx context.Context, engineUUID uuid.UUID) err
 	return nil
 }
 
-func (local *local) CheckRequirements() error {
-	if err := checkTiDBVersion(local.tls, localMinTiDBVersion); err != nil {
+func (local *local) CheckRequirements(ctx context.Context) error {
+	if err := checkTiDBVersion(ctx, local.tls, localMinTiDBVersion); err != nil {
 		return err
 	}
-	if err := checkPDVersion(local.tls, local.pdAddr, localMinPDVersion); err != nil {
+	if err := checkPDVersion(ctx, local.tls, local.pdAddr, localMinPDVersion); err != nil {
 		return err
 	}
-	if err := checkTiKVVersion(local.tls, local.pdAddr, localMinTiKVVersion); err != nil {
+	if err := checkTiKVVersion(ctx, local.tls, local.pdAddr, localMinTiKVVersion); err != nil {
 		return err
 	}
 	return nil
 }
 
 func (local *local) FetchRemoteTableModels(ctx context.Context, schemaName string) ([]*model.TableInfo, error) {
-	return fetchRemoteTableModelsFromTLS(local.tls, schemaName)
+	return fetchRemoteTableModelsFromTLS(ctx, local.tls, schemaName)
 }
 
 func (local *local) WriteRows(

--- a/lightning/backend/tidb.go
+++ b/lightning/backend/tidb.go
@@ -285,7 +285,7 @@ func (be *tidbBackend) ShouldPostProcess() bool {
 	return false
 }
 
-func (be *tidbBackend) CheckRequirements() error {
+func (be *tidbBackend) CheckRequirements(ctx context.Context) error {
 	log.L().Info("skipping check requirements for tidb backend")
 	return nil
 }

--- a/lightning/backend/tikv.go
+++ b/lightning/backend/tikv.go
@@ -113,7 +113,7 @@ func ForAllStores(
 			Store Store
 		}
 	}
-	err := tls.GetJSON("/pd/api/v1/stores", &stores)
+	err := tls.GetJSONWithContext(ctx, "/pd/api/v1/stores", &stores)
 	if err != nil {
 		return err
 	}

--- a/lightning/backend/tikv.go
+++ b/lightning/backend/tikv.go
@@ -113,7 +113,7 @@ func ForAllStores(
 			Store Store
 		}
 	}
-	err := tls.GetJSONWithContext(ctx, "/pd/api/v1/stores", &stores)
+	err := tls.GetJSON(ctx, "/pd/api/v1/stores", &stores)
 	if err != nil {
 		return err
 	}

--- a/lightning/common/security.go
+++ b/lightning/common/security.go
@@ -145,11 +145,6 @@ func (tc *TLS) WrapListener(l net.Listener) net.Listener {
 	return tls.NewListener(l, tc.inner)
 }
 
-// GetJSON obtains JSON result with the HTTP GET method.
-func (tc *TLS) GetJSON(path string, v interface{}) error {
-	return tc.GetJSONWithContext(context.TODO(), path, v)
-}
-
 func (tc *TLS) GetJSONWithContext(ctx context.Context, path string, v interface{}) error {
 	return GetJSON(ctx, tc.client, tc.url+path, v)
 }

--- a/lightning/common/security.go
+++ b/lightning/common/security.go
@@ -14,6 +14,7 @@
 package common
 
 import (
+	"context"
 	"crypto/tls"
 	"crypto/x509"
 	"io/ioutil"
@@ -146,7 +147,11 @@ func (tc *TLS) WrapListener(l net.Listener) net.Listener {
 
 // GetJSON obtains JSON result with the HTTP GET method.
 func (tc *TLS) GetJSON(path string, v interface{}) error {
-	return GetJSON(tc.client, tc.url+path, v)
+	return tc.GetJSONWithContext(context.TODO(), path, v)
+}
+
+func (tc *TLS) GetJSONWithContext(ctx context.Context, path string, v interface{}) error {
+	return GetJSON(ctx, tc.client, tc.url+path, v)
 }
 
 func (tc *TLS) ToPDSecurityOption() pd.SecurityOption {

--- a/lightning/common/security.go
+++ b/lightning/common/security.go
@@ -145,7 +145,7 @@ func (tc *TLS) WrapListener(l net.Listener) net.Listener {
 	return tls.NewListener(l, tc.inner)
 }
 
-func (tc *TLS) GetJSONWithContext(ctx context.Context, path string, v interface{}) error {
+func (tc *TLS) GetJSON(ctx context.Context, path string, v interface{}) error {
 	return GetJSON(ctx, tc.client, tc.url+path, v)
 }
 

--- a/lightning/common/security_test.go
+++ b/lightning/common/security_test.go
@@ -14,6 +14,7 @@
 package common_test
 
 import (
+	"context"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -40,6 +41,7 @@ func (s *securitySuite) TestGetJSONInsecure(c *C) {
 	mockServer := httptest.NewServer(http.HandlerFunc(respondPathHandler))
 	defer mockServer.Close()
 
+	ctx := context.Background()
 	u, err := url.Parse(mockServer.URL)
 	c.Assert(err, IsNil)
 
@@ -47,10 +49,10 @@ func (s *securitySuite) TestGetJSONInsecure(c *C) {
 	c.Assert(err, IsNil)
 
 	var result struct{ Path string }
-	err = tls.GetJSON("/aaa", &result)
+	err = tls.GetJSONWithContext(ctx, "/aaa", &result)
 	c.Assert(err, IsNil)
 	c.Assert(result.Path, Equals, "/aaa")
-	err = tls.GetJSON("/bbbb", &result)
+	err = tls.GetJSONWithContext(ctx, "/bbbb", &result)
 	c.Assert(err, IsNil)
 	c.Assert(result.Path, Equals, "/bbbb")
 }
@@ -59,13 +61,14 @@ func (s *securitySuite) TestGetJSONSecure(c *C) {
 	mockServer := httptest.NewTLSServer(http.HandlerFunc(respondPathHandler))
 	defer mockServer.Close()
 
+	ctx := context.Background()
 	tls := common.NewTLSFromMockServer(mockServer)
 
 	var result struct{ Path string }
-	err := tls.GetJSON("/ccc", &result)
+	err := tls.GetJSONWithContext(ctx, "/ccc", &result)
 	c.Assert(err, IsNil)
 	c.Assert(result.Path, Equals, "/ccc")
-	err = tls.GetJSON("/dddd", &result)
+	err = tls.GetJSONWithContext(ctx, "/dddd", &result)
 	c.Assert(err, IsNil)
 	c.Assert(result.Path, Equals, "/dddd")
 }

--- a/lightning/common/security_test.go
+++ b/lightning/common/security_test.go
@@ -49,10 +49,10 @@ func (s *securitySuite) TestGetJSONInsecure(c *C) {
 	c.Assert(err, IsNil)
 
 	var result struct{ Path string }
-	err = tls.GetJSONWithContext(ctx, "/aaa", &result)
+	err = tls.GetJSON(ctx, "/aaa", &result)
 	c.Assert(err, IsNil)
 	c.Assert(result.Path, Equals, "/aaa")
-	err = tls.GetJSONWithContext(ctx, "/bbbb", &result)
+	err = tls.GetJSON(ctx, "/bbbb", &result)
 	c.Assert(err, IsNil)
 	c.Assert(result.Path, Equals, "/bbbb")
 }
@@ -65,10 +65,10 @@ func (s *securitySuite) TestGetJSONSecure(c *C) {
 	tls := common.NewTLSFromMockServer(mockServer)
 
 	var result struct{ Path string }
-	err := tls.GetJSONWithContext(ctx, "/ccc", &result)
+	err := tls.GetJSON(ctx, "/ccc", &result)
 	c.Assert(err, IsNil)
 	c.Assert(result.Path, Equals, "/ccc")
-	err = tls.GetJSONWithContext(ctx, "/dddd", &result)
+	err = tls.GetJSON(ctx, "/dddd", &result)
 	c.Assert(err, IsNil)
 	c.Assert(result.Path, Equals, "/dddd")
 }

--- a/lightning/common/util.go
+++ b/lightning/common/util.go
@@ -276,11 +276,17 @@ func WriteMySQLIdentifier(builder *strings.Builder, identifier string) {
 //		return errors.Trace(err)
 //	}
 //	fmt.Println(resp.IP)
-func GetJSON(client *http.Client, url string, v interface{}) error {
-	resp, err := client.Get(url)
+func GetJSON(ctx context.Context, client *http.Client, url string, v interface{}) error {
+	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
 	if err != nil {
 		return errors.Trace(err)
 	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return errors.Trace(err)
+	}
+
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {

--- a/lightning/common/util_test.go
+++ b/lightning/common/util_test.go
@@ -54,6 +54,7 @@ func (s *utilSuite) TestGetJSON(c *C) {
 		Password: "lightning-ctl",
 	}
 
+	ctx := context.Background()
 	// Mock success response
 	handle := func(res http.ResponseWriter, req *http.Request) {
 		res.WriteHeader(http.StatusOK)
@@ -68,9 +69,9 @@ func (s *utilSuite) TestGetJSON(c *C) {
 	client := &http.Client{Timeout: time.Second}
 
 	response := TestPayload{}
-	err := common.GetJSON(client, "http://not-exists", &response)
+	err := common.GetJSON(ctx, client, "http://not-exists", &response)
 	c.Assert(err, NotNil)
-	err = common.GetJSON(client, testServer.URL, &response)
+	err = common.GetJSON(ctx, client, testServer.URL, &response)
 	c.Assert(err, IsNil)
 	c.Assert(request, DeepEquals, response)
 
@@ -78,7 +79,7 @@ func (s *utilSuite) TestGetJSON(c *C) {
 	handle = func(res http.ResponseWriter, req *http.Request) {
 		res.WriteHeader(http.StatusNoContent)
 	}
-	err = common.GetJSON(client, testServer.URL, &response)
+	err = common.GetJSON(ctx, client, testServer.URL, &response)
 	c.Assert(err, NotNil)
 	c.Assert(err, ErrorMatches, ".*http status code != 200.*")
 }

--- a/lightning/common/version.go
+++ b/lightning/common/version.go
@@ -66,7 +66,7 @@ func PrintInfo(app string, callback func()) {
 // FetchPDVersion get pd version
 func FetchPDVersion(ctx context.Context, tls *TLS, pdAddr string) (*semver.Version, error) {
 	var rawVersion string
-	err := tls.WithHost(pdAddr).GetJSONWithContext(ctx, "/pd/api/v1/config/cluster-version", &rawVersion)
+	err := tls.WithHost(pdAddr).GetJSON(ctx, "/pd/api/v1/config/cluster-version", &rawVersion)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/lightning/common/version.go
+++ b/lightning/common/version.go
@@ -14,6 +14,7 @@
 package common
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -63,9 +64,9 @@ func PrintInfo(app string, callback func()) {
 }
 
 // FetchPDVersion get pd version
-func FetchPDVersion(tls *TLS, pdAddr string) (*semver.Version, error) {
+func FetchPDVersion(ctx context.Context, tls *TLS, pdAddr string) (*semver.Version, error) {
 	var rawVersion string
-	err := tls.WithHost(pdAddr).GetJSON("/pd/api/v1/config/cluster-version", &rawVersion)
+	err := tls.WithHost(pdAddr).GetJSONWithContext(ctx, "/pd/api/v1/config/cluster-version", &rawVersion)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/lightning/config/config.go
+++ b/lightning/config/config.go
@@ -14,6 +14,7 @@
 package config
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net"
@@ -459,7 +460,7 @@ func (cfg *Config) LoadFromTOML(data []byte) error {
 }
 
 // Adjust fixes the invalid or unspecified settings to reasonable valid values.
-func (cfg *Config) Adjust() error {
+func (cfg *Config) Adjust(ctx context.Context) error {
 	// Reject problematic CSV configurations.
 	csv := &cfg.Mydumper.CSV
 	if len(csv.Separator) == 0 {
@@ -579,7 +580,7 @@ func (cfg *Config) Adjust() error {
 		}
 
 		var settings tidbcfg.Config
-		err = tls.GetJSON("/settings", &settings)
+		err = tls.GetJSONWithContext(ctx, "/settings", &settings)
 		if err != nil {
 			return errors.Annotate(err, "cannot fetch settings from TiDB, please manually fill in `tidb.port` and `tidb.pd-addr`")
 		}

--- a/lightning/config/config.go
+++ b/lightning/config/config.go
@@ -580,7 +580,7 @@ func (cfg *Config) Adjust(ctx context.Context) error {
 		}
 
 		var settings tidbcfg.Config
-		err = tls.GetJSONWithContext(ctx, "/settings", &settings)
+		err = tls.GetJSON(ctx, "/settings", &settings)
 		if err != nil {
 			return errors.Annotate(err, "cannot fetch settings from TiDB, please manually fill in `tidb.port` and `tidb.pd-addr`")
 		}

--- a/lightning/config/config_test.go
+++ b/lightning/config/config_test.go
@@ -137,17 +137,18 @@ func (s *configTestSuite) TestAdjustFileRoutePath(c *C) {
 	cfg := config.NewConfig()
 	assignMinimalLegalValue(cfg)
 
+	ctx := context.Background()
 	tmpDir := c.MkDir()
 	cfg.Mydumper.SourceDir = tmpDir
 	invalidPath := filepath.Join(tmpDir, "../test123/1.sql")
 	rule := &config.FileRouteRule{Path: invalidPath, Type: "sql", Schema: "test", Table: "tbl"}
 	cfg.Mydumper.FileRouters = []*config.FileRouteRule{rule}
-	err := cfg.Adjust()
+	err := cfg.Adjust(ctx)
 	c.Assert(err, ErrorMatches, fmt.Sprintf("file route path '%s' is not in source dir '%s'", invalidPath, tmpDir))
 
 	relPath := "test_dir/1.sql"
 	rule.Path = filepath.Join(tmpDir, relPath)
-	err = cfg.Adjust()
+	err = cfg.Adjust(ctx)
 	c.Assert(err, IsNil)
 	c.Assert(cfg.Mydumper.FileRouters[0].Path, Equals, relPath)
 }

--- a/lightning/lightning.go
+++ b/lightning/lightning.go
@@ -174,7 +174,7 @@ func (l *Lightning) RunOnce() error {
 	if err := cfg.LoadFromGlobal(l.globalCfg); err != nil {
 		return err
 	}
-	if err := cfg.Adjust(); err != nil {
+	if err := cfg.Adjust(l.ctx); err != nil {
 		return err
 	}
 
@@ -434,7 +434,7 @@ func (l *Lightning) handlePostTask(w http.ResponseWriter, req *http.Request) {
 		writeJSONError(w, http.StatusBadRequest, "cannot parse task (must be TOML)", err)
 		return
 	}
-	if err = cfg.Adjust(); err != nil {
+	if err = cfg.Adjust(l.ctx); err != nil {
 		writeJSONError(w, http.StatusBadRequest, "invalid task configuration", err)
 		return
 	}

--- a/lightning/restore/checksum.go
+++ b/lightning/restore/checksum.go
@@ -65,7 +65,7 @@ func newChecksumManager(ctx context.Context, rc *RestoreController) (ChecksumMan
 	var manager ChecksumManager
 	if pdVersion.Major >= 4 {
 		tlsOpt := rc.tls.ToPDSecurityOption()
-		pdCli, err := pd.NewClient([]string{pdAddr}, tlsOpt)
+		pdCli, err := pd.NewClientWithContext(ctx, []string{pdAddr}, tlsOpt)
 		if err != nil {
 			return nil, errors.Trace(err)
 		}

--- a/lightning/restore/checksum.go
+++ b/lightning/restore/checksum.go
@@ -49,14 +49,14 @@ type ChecksumManager interface {
 	Checksum(ctx context.Context, tableInfo *TidbTableInfo) (*RemoteChecksum, error)
 }
 
-func newChecksumManager(rc *RestoreController) (ChecksumManager, error) {
+func newChecksumManager(ctx context.Context, rc *RestoreController) (ChecksumManager, error) {
 	// if we don't need checksum, just return nil
 	if rc.cfg.TikvImporter.Backend == config.BackendTiDB || rc.cfg.PostRestore.Checksum == config.OpLevelOff {
 		return nil, nil
 	}
 
 	pdAddr := rc.cfg.TiDB.PdAddr
-	pdVersion, err := common.FetchPDVersion(rc.tls, pdAddr)
+	pdVersion, err := common.FetchPDVersion(ctx, rc.tls, pdAddr)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/lightning/restore/restore.go
+++ b/lightning/restore/restore.go
@@ -678,7 +678,7 @@ func (rc *RestoreController) restoreTables(ctx context.Context) error {
 	taskCh := make(chan task, rc.cfg.App.IndexConcurrency)
 	defer close(taskCh)
 
-	manager, err := newChecksumManager(rc)
+	manager, err := newChecksumManager(ctx, rc)
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -1301,12 +1301,12 @@ func (rc *RestoreController) switchTiKVMode(ctx context.Context, mode sstpb.Swit
 	)
 }
 
-func (rc *RestoreController) checkRequirements(_ context.Context) error {
+func (rc *RestoreController) checkRequirements(ctx context.Context) error {
 	// skip requirement check if explicitly turned off
 	if !rc.cfg.App.CheckRequirements {
 		return nil
 	}
-	return rc.backend.CheckRequirements()
+	return rc.backend.CheckRequirements(ctx)
 }
 
 func (rc *RestoreController) setGlobalVariables(ctx context.Context) error {

--- a/mock/backend.go
+++ b/mock/backend.go
@@ -46,17 +46,17 @@ func (m *MockBackend) EXPECT() *MockBackendMockRecorder {
 }
 
 // CheckRequirements mocks base method
-func (m *MockBackend) CheckRequirements() error {
+func (m *MockBackend) CheckRequirements(arg0 context.Context) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CheckRequirements")
+	ret := m.ctrl.Call(m, "CheckRequirements", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // CheckRequirements indicates an expected call of CheckRequirements
-func (mr *MockBackendMockRecorder) CheckRequirements() *gomock.Call {
+func (mr *MockBackendMockRecorder) CheckRequirements(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CheckRequirements", reflect.TypeOf((*MockBackend)(nil).CheckRequirements))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CheckRequirements", reflect.TypeOf((*MockBackend)(nil).CheckRequirements), arg0)
 }
 
 // CleanupEngine mocks base method


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-Lightning! Please read the [CONTRIBUTING](https://github.com/pingcap/tidb-lightning/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Replace some usage of `context.Backend` or `context.TODO` with lightning app context. So we can stop some sub task more quickly.

close #462 

### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

Side effects

Related changes
