### PR TITLE
mydumper: verify file routing config

### DIFF
--- a/lightning/config/config.go
+++ b/lightning/config/config.go
@@ -479,6 +479,23 @@ func (cfg *Config) Adjust() error {
 		}
 	}
 
+	// adjust file routing
+	for _, rule := range cfg.Mydumper.FileRouters {
+		if rule.Path != "" {
+			if filepath.IsAbs(rule.Path) {
+				relPath, err := filepath.Rel(cfg.Mydumper.SourceDir, rule.Path)
+				if err != nil {
+					return errors.Trace(err)
+				}
+				// ".." means that this path is not in source dir, so we should return an error
+				if strings.HasPrefix(relPath, "..") {
+					return errors.Errorf("file route path '%s' is not in source dir '%s'", rule.Path, cfg.Mydumper.SourceDir)
+				}
+				rule.Path = relPath
+			}
+		}
+	}
+
 	// enable default file route rule if no rules are set
 	if len(cfg.Mydumper.FileRouters) == 0 {
 		cfg.Mydumper.DefaultFileRules = true

--- a/lightning/config/config.go
+++ b/lightning/config/config.go
@@ -481,18 +481,16 @@ func (cfg *Config) Adjust() error {
 
 	// adjust file routing
 	for _, rule := range cfg.Mydumper.FileRouters {
-		if rule.Path != "" {
-			if filepath.IsAbs(rule.Path) {
-				relPath, err := filepath.Rel(cfg.Mydumper.SourceDir, rule.Path)
-				if err != nil {
-					return errors.Trace(err)
-				}
-				// ".." means that this path is not in source dir, so we should return an error
-				if strings.HasPrefix(relPath, "..") {
-					return errors.Errorf("file route path '%s' is not in source dir '%s'", rule.Path, cfg.Mydumper.SourceDir)
-				}
-				rule.Path = relPath
+		if filepath.IsAbs(rule.Path) {
+			relPath, err := filepath.Rel(cfg.Mydumper.SourceDir, rule.Path)
+			if err != nil {
+				return errors.Trace(err)
 			}
+			// ".." means that this path is not in source dir, so we should return an error
+			if strings.HasPrefix(relPath, "..") {
+				return errors.Errorf("file route path '%s' is not in source dir '%s'", rule.Path, cfg.Mydumper.SourceDir)
+			}
+			rule.Path = relPath
 		}
 	}
 

--- a/lightning/config/config_test.go
+++ b/lightning/config/config_test.go
@@ -132,6 +132,25 @@ func (s *configTestSuite) TestAdjustInvalidBackend(c *C) {
 	c.Assert(err, ErrorMatches, "invalid config: unsupported `tikv-importer\\.backend` \\(no_such_backend\\)")
 }
 
+func (s *configTestSuite) TestAdjustFileRoutePath(c *C) {
+	cfg := config.NewConfig()
+	assignMinimalLegalValue(cfg)
+
+	tmpDir := c.MkDir()
+	cfg.Mydumper.SourceDir = tmpDir
+	invalidPath := filepath.Join(tmpDir, "../test123/1.sql")
+	rule := &config.FileRouteRule{Path: invalidPath, Type: "sql", Schema: "test", Table: "tbl"}
+	cfg.Mydumper.FileRouters = []*config.FileRouteRule{rule}
+	err := cfg.Adjust()
+	c.Assert(err, ErrorMatches, fmt.Sprintf("file route path '%s' is not in source dir '%s'", invalidPath, tmpDir))
+
+	relPath := "test_dir/1.sql"
+	rule.Path = filepath.Join(tmpDir, relPath)
+	err = cfg.Adjust()
+	c.Assert(err, IsNil)
+	c.Assert(cfg.Mydumper.FileRouters[0].Path, Equals, relPath)
+}
+
 func (s *configTestSuite) TestDecodeError(c *C) {
 	ts, host, port := startMockServer(c, http.StatusOK, "invalid-string")
 	defer ts.Close()

--- a/lightning/mydump/router.go
+++ b/lightning/mydump/router.go
@@ -176,6 +176,9 @@ type regexRouterParser struct{}
 
 func (p regexRouterParser) Parse(r *config.FileRouteRule) (*RegexRouter, error) {
 	rule := &RegexRouter{}
+	if r.Path == "" && r.Pattern == "" {
+		return nil, errors.New("`path` and `pattern` must not be both empty in [[mydumper.files]]")
+	}
 	if r.Path != "" && r.Pattern != "" {
 		return nil, errors.New("can't set both `path` and `pattern` field in [[mydumper.files]]")
 	}

--- a/lightning/mydump/router_test.go
+++ b/lightning/mydump/router_test.go
@@ -41,14 +41,7 @@ func (t *testFileRouterSuite) TestRouteParser(c *C) {
 }
 
 func (t *testFileRouterSuite) TestInvalidRouteRule(c *C) {
-	rule := &config.FileRouteRule{
-		Schema:      "$1",
-		Table:       "$table",
-		Type:        "$type",
-		Key:         "$key",
-		Compression: "$cp",
-	}
-	rule = &config.FileRouteRule{}
+	rule := &config.FileRouteRule{}
 	rules := []*config.FileRouteRule{rule}
 	_, err := NewFileRouter(rules)
 	c.Assert(err, ErrorMatches, "`path` and `pattern` must not be both empty in \\[\\[mydumper.files\\]\\]")


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-Lightning! Please read the [CONTRIBUTING](https://github.com/pingcap/tidb-lightning/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
- Add checksum for file routing `pattern` and `path` both empty
- Allow absolute path for `mydumper.files.path`, convert it to the relative path at `config.Adjust`

close #469 

### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

Side effects

Related changes
