### PR TITLE
mydumper: convert parquet columns to lower case

### DIFF
--- a/lightning/mydump/parquet_parser.go
+++ b/lightning/mydump/parquet_parser.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"reflect"
+	"strings"
 	"time"
 
 	"github.com/pingcap/br/pkg/storage"
@@ -89,7 +90,7 @@ func NewParquetParser(
 	for i, c := range reader.SchemaHandler.SchemaElements {
 		if c.GetNumChildren() == 0 {
 			// the SchemaElement.Name is capitalized, we should use the original name
-			columns = append(columns, reader.SchemaHandler.Infos[i].ExName)
+			columns = append(columns, strings.ToLower(reader.SchemaHandler.Infos[i].ExName))
 			columnMetas = append(columnMetas, c)
 		}
 	}

--- a/lightning/mydump/parquet_parser.go
+++ b/lightning/mydump/parquet_parser.go
@@ -87,10 +87,11 @@ func NewParquetParser(
 
 	columns := make([]string, 0, len(reader.Footer.Schema)-1)
 	columnMetas := make([]*parquet.SchemaElement, 0, len(reader.Footer.Schema)-1)
-	for i, c := range reader.SchemaHandler.SchemaElements {
+	for _, c := range reader.SchemaHandler.SchemaElements {
 		if c.GetNumChildren() == 0 {
-			// the SchemaElement.Name is capitalized, we should use the original name
-			columns = append(columns, strings.ToLower(reader.SchemaHandler.Infos[i].ExName))
+			// NOTE: the SchemaElement.Name is capitalized, SchemaHandler.Infos.ExName is the raw column name
+			// though in this context, there is no difference between these two fields
+			columns = append(columns, strings.ToLower(c.Name))
 			columnMetas = append(columnMetas, c)
 		}
 	}

--- a/lightning/mydump/parquet_parser_test.go
+++ b/lightning/mydump/parquet_parser_test.go
@@ -19,8 +19,8 @@ var _ = Suite(testParquetParserSuite{})
 
 func (s testParquetParserSuite) TestParquetParser(c *C) {
 	type Test struct {
-		S string `parquet:"name=s, type=UTF8, encoding=PLAIN_DICTIONARY"`
-		A int32  `parquet:"name=a, type=INT32"`
+		S string `parquet:"name=sS, type=UTF8, encoding=PLAIN_DICTIONARY"`
+		A int32  `parquet:"name=a_A, type=INT32"`
 	}
 
 	dir := c.MkDir()
@@ -50,7 +50,7 @@ func (s testParquetParserSuite) TestParquetParser(c *C) {
 	c.Assert(err, IsNil)
 	defer reader.Close()
 
-	c.Assert(reader.Columns(), DeepEquals, []string{"s", "a"})
+	c.Assert(reader.Columns(), DeepEquals, []string{"ss", "a_a"})
 
 	verifyRow := func(i int) {
 		c.Assert(reader.lastRow.RowID, Equals, int64(i+1))

--- a/tests/checkpoint_parquet/parquet.go
+++ b/tests/checkpoint_parquet/parquet.go
@@ -21,7 +21,7 @@ var (
 
 func genParquetFile(dir, name string, count int) error {
 	type Test struct {
-		I int32  `parquet:"name=i, type=INT32"`
+		I int32  `parquet:"name=iVal, type=INT32"`
 		S string `parquet:"name=s, type=UTF8, encoding=PLAIN_DICTIONARY"`
 	}
 

--- a/tests/checkpoint_parquet/run.sh
+++ b/tests/checkpoint_parquet/run.sh
@@ -25,7 +25,8 @@ do_run_lightning() {
 
 mkdir -p $DBPATH
 echo 'CREATE DATABASE cppq_tsr;' > "$DBPATH/cppq_tsr-schema-create.sql"
-echo 'CREATE TABLE tbl(i INT, s VARCHAR(16));' > "$DBPATH/cppq_tsr.tbl-schema.sql"
+# column "iVal" use for testing column name with upper case is properly handled
+echo 'CREATE TABLE tbl(iVal INT, s VARCHAR(16));' > "$DBPATH/cppq_tsr.tbl-schema.sql"
 bin/parquet_gen --dir $DBPATH --schema cppq_tsr --table tbl --chunk 1 --rows $ROW_COUNT
 
 # Set the failpoint to kill the lightning instance as soon as one batch data is written
@@ -38,10 +39,10 @@ run_sql 'DROP DATABASE IF EXISTS checkpoint_test_parquet'
 set +e
 run_lightning -d "$DBPATH" --backend tidb --enable-checkpoint=1 2> /dev/null
 set -e
-run_sql 'SELECT count(*), sum(i) FROM `cppq_tsr`.tbl'
+run_sql 'SELECT count(*), sum(iVal) FROM `cppq_tsr`.tbl'
 check_contains "count(*): 32"
 # sum(0..31)
-check_contains "sum(i): 496"
+check_contains "sum(iVal): 496"
 
 # check chunk offset and update checkpoint current row id to a higher value so that
 # if parse read from start, the generated rows will be different
@@ -53,7 +54,7 @@ set +e
 run_lightning -d "$DBPATH" --backend tidb --enable-checkpoint=1 2> /dev/null
 set -e
 
-run_sql 'SELECT count(*), sum(i) FROM `cppq_tsr`.tbl'
+run_sql 'SELECT count(*), sum(iVal) FROM `cppq_tsr`.tbl'
 check_contains "count(*): 100"
 # sum(0..99)
-check_contains "sum(i): 4950"
+check_contains "sum(iVal): 4950"


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-Lightning! Please read the [CONTRIBUTING](https://github.com/pingcap/tidb-lightning/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Convert parquet reader columns to lower case to be compatible with other logics involving the column names

close #480 

### What is changed and how it works?

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - No code

Side effects

Related changes
