### PR TITLE
test: fix an unstable integration test

### DIFF
--- a/tests/column_permutation/data/perm.test_perm-schema.sql
+++ b/tests/column_permutation/data/perm.test_perm-schema.sql
@@ -1,4 +1,4 @@
-CREATE TABLE `test` (
+CREATE TABLE `test_perm` (
 	`id` int(11) NOT NULL,
 	`contract_no` varchar(64) DEFAULT NULL,
 	`fund_seq_no` varchar(64) DEFAULT NULL,
@@ -8,7 +8,7 @@ CREATE TABLE `test` (
 	`prin_amt` int(11) DEFAULT NULL,
 	`start_date` varchar(8) DEFAULT NULL,
 	`end_date` varchar(8) DEFAULT NULL,
-	`batch_date` varchar(8) DEFAULT NULL,
+	`batch_date` varchar(32) DEFAULT NULL,
 	`crt_time` timestamp DEFAULT CURRENT_TIMESTAMP,
 	`region_code` varchar(8) DEFAULT NULL,
 	`credit_code` varchar(64) DEFAULT NULL


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-Lightning! Please read the [CONTRIBUTING](https://github.com/pingcap/tidb-lightning/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Fix an integration test that failed to create table with:
```
[2020-11-25T06:33:57.764Z] [2020/11/25 14:33:56.121 +08:00] [WARN] [session.go:1245] ["run statement failed"] [conn=6688656886226485375] [schemaVersion=78] [error="[types:1406]Data Too Long, field len 8, data len 19"] [session="{\n  \"currDBName\": \"\",\n  \"id\": 6688656886226485375,\n  \"status\": 2,\n  \"strictMode\": false,\n  \"user\": {\n    \"Username\": \"root\",\n    \"Hostname\": \"127.0.0.1\",\n    \"CurrentUser\": false,\n    \"AuthUsername\": \"root\",\n    \"AuthHostname\": \"%\"\n  }\n}"]

[2020-11-25T06:33:57.764Z] [2020/11/25 14:33:56.121 +08:00] [INFO] [conn.go:801] ["command dispatched failed"] [conn=6688656886226485375] [connInfo="id:6688656886226485375, addr:127.0.0.1:53080 status:10, collation:utf8mb4_general_ci, user:root"] [command=Query] [status="inTxn:0, autocommit:1"] [sql="CREATE TABLE IF NOT EXISTS `perm`.`test_perm` (`id` INT(11) NOT NULL,`contract_no` VARCHAR(64) DEFAULT NULL,`fund_seq_no` VARCHAR(64) DEFAULT NULL,`term_no` INT(11) DEFAULT NULL,`contract_type` VARCHAR(8) DEFAULT NULL,`internal_transfer_tag` VARCHAR(8) DEFAULT NULL,`prin_amt` INT(11) DEFAULT NULL,`start_date` VARCHAR(8) DEFAULT NULL,`end_date` VARCHAR(8) DEFAULT NULL,`batch_date` VARCHAR(8) DEFAULT NULL,`crt_time` TIMESTAMP DEFAULT CURRENT_TIMESTAMP(),`region_code` VARCHAR(8) DEFAULT NULL,`credit_code` VARCHAR(64) DEFAULT NULL) ENGINE = InnoDB DEFAULT CHARACTER SET = UTF8MB4 DEFAULT COLLATE = UTF8MB4_BIN PARTITION BY RANGE COLUMNS (`batch_date`) (PARTITION `P20200224` VALUES LESS THAN ('2020-02-05 00:00:00'),PARTITION `P20200324` VALUES LESS THAN ('2020-03-05 00:00:00'),PARTITION `P20200424` VALUES LESS THAN ('2020-04-05 00:00:00'),PARTITION `P20200524` VALUES LESS THAN ('2020-05-05 00:00:00'),PARTITION `P_MAXVALUE` VALUES LESS THAN (MAXVALUE));"] [txn_mode=PESSIMISTIC] [err="[types:1406]Data Too Long, field len 8, data len 19
```

### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

Side effects

Related changes
