### PR TITLE
test: fix can not kill tiflash process by name

### DIFF
--- a/tests/_utils/run_services
+++ b/tests/_utils/run_services
@@ -4,6 +4,8 @@ stop_services() {
     killall -9 tidb-server || true
     killall -9 tikv-importer || true
     killall -9 tiflash || true
+    # the newest tiflash process name is "TiFlashMain"
+    killall -9 TiFlashMain || true
 
     find "$TEST_DIR" -maxdepth 1 -not -path "$TEST_DIR" -not -name "cov.*" -not -name "*.log" | xargs rm -rf || true
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-Lightning! Please read the [CONTRIBUTING](https://github.com/pingcap/tidb-lightning/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Fix test failure due to can't restart tiflash

### What is changed and how it works?
The newest tiflash process is "TiFlashMain", so use `killall tiflash` cannot kill it.
```
ps aux |grep tiflash
root      12530 15.5  0.8 3316776 1714152 pts/4 Sl   11:23   0:10 bin/tiflash server --config-file=/tmp/lightning_test_result/tiflash.toml

ps -p 12530 -o comm=
TiFlashMain
```

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

Side effects

Related changes
