### PR TITLE
backend/local: set pebble db max file limit

### DIFF
--- a/lightning/backend/local_unix.go
+++ b/lightning/backend/local_unix.go
@@ -18,12 +18,11 @@ package backend
 import (
 	"syscall"
 
+	"github.com/pingcap/errors"
+	"github.com/pingcap/failpoint"
 	"go.uber.org/zap"
 
 	"github.com/pingcap/tidb-lightning/lightning/log"
-
-	"github.com/pingcap/errors"
-	"github.com/pingcap/failpoint"
 )
 
 const (

--- a/lightning/backend/local_unix.go
+++ b/lightning/backend/local_unix.go
@@ -18,14 +18,32 @@ package backend
 import (
 	"syscall"
 
+	"go.uber.org/zap"
+
+	"github.com/pingcap/tidb-lightning/lightning/log"
+
 	"github.com/pingcap/errors"
 	"github.com/pingcap/failpoint"
 )
+
+const (
+	// mininum max open files value
+	minRLimit = 1024
+)
+
+func GetSystemRLimit() (uint64, error) {
+	var rLimit syscall.Rlimit
+	err := syscall.Getrlimit(syscall.RLIMIT_NOFILE, &rLimit)
+	return rLimit.Cur, err
+}
 
 // VerifyRLimit checks whether the open-file limit is large enough.
 // In Local-backend, we need to read and write a lot of L0 SST files, so we need
 // to check system max open files limit.
 func VerifyRLimit(estimateMaxFiles uint64) error {
+	if estimateMaxFiles < minRLimit {
+		estimateMaxFiles = minRLimit
+	}
 	var rLimit syscall.Rlimit
 	err := syscall.Getrlimit(syscall.RLIMIT_NOFILE, &rLimit)
 	failpoint.Inject("GetRlimitValue", func(v failpoint.Value) {
@@ -57,5 +75,19 @@ func VerifyRLimit(estimateMaxFiles uint64) error {
 	if err != nil {
 		return errors.Annotatef(err, "the maximum number of open file descriptors is too small, got %d, expect greater or equal to %d", prevLimit, estimateMaxFiles)
 	}
+
+	// fetch the rlimit again to make sure our setting has taken effect
+	err = syscall.Getrlimit(syscall.RLIMIT_NOFILE, &rLimit)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	if rLimit.Cur < estimateMaxFiles {
+		helper := "Please manually execute `ulimit -n %d` to increase the open files limit."
+		return errors.Errorf("cannot update the maximum number of open file descriptors, expected: %d, got: %d. %s",
+			estimateMaxFiles, rLimit.Cur, helper)
+	}
+
+	log.L().Info("Set the maximum number of open file descriptors(rlimit)",
+		zap.Uint64("old", prevLimit), zap.Uint64("new", estimateMaxFiles))
 	return nil
 }

--- a/lightning/backend/local_windows.go
+++ b/lightning/backend/local_windows.go
@@ -16,8 +16,15 @@
 package backend
 
 import (
+	"math"
+
 	"github.com/pingcap/errors"
 )
+
+// return a big value as unlimited, since rlimit verify is skipped in windows.
+func GetSystemRLimit() (uint64, error) {
+	return math.MaxInt32, nil
+}
 
 func VerifyRLimit(estimateMaxFiles uint64) error {
 	return errors.New("Local-backend is not tested on Windows. Run with --check-requirements=false to disable this check, but you are on your own risk.")

--- a/lightning/lightning.go
+++ b/lightning/lightning.go
@@ -651,6 +651,11 @@ func handleLogLevel(w http.ResponseWriter, req *http.Request) {
 }
 
 func checkSystemRequirement(cfg *config.Config, dbsMeta []*mydump.MDDatabaseMeta) error {
+	if !cfg.App.CheckRequirements {
+		log.L().Info("check-requirement is disabled, skip check system rlimit")
+		return nil
+	}
+
 	// in local mode, we need to read&write a lot of L0 sst files, so we need to check system max open files limit
 	if cfg.TikvImporter.Backend == config.BackendLocal {
 		// estimate max open files = {top N(TableConcurrency) table sizes} / {MemoryTableSize}

--- a/lightning/lightning.go
+++ b/lightning/lightning.go
@@ -668,7 +668,7 @@ func checkSystemRequirement(cfg *config.Config, dbsMeta []*mydump.MDDatabaseMeta
 			topNTotalSize += tableTotalSizes[i]
 		}
 
-		estimateMaxFiles := uint64(topNTotalSize / backend.LocalMemoryTableSize)
+		estimateMaxFiles := uint64(topNTotalSize/backend.LocalMemoryTableSize) * 2
 		if err := backend.VerifyRLimit(estimateMaxFiles); err != nil {
 			return err
 		}

--- a/lightning/lightning_test.go
+++ b/lightning/lightning_test.go
@@ -478,7 +478,8 @@ func (s *lightningServerSuite) TestCheckSystemRequirement(c *C) {
 	err = failpoint.Disable("github.com/pingcap/tidb-lightning/lightning/backend/GetRlimitValue")
 	c.Assert(err, IsNil)
 
-	err = failpoint.Enable("github.com/pingcap/tidb-lightning/lightning/backend/GetRlimitValue", "return(1025)")
+	// the min rlimit should be bigger than the default min value (16384)
+	err = failpoint.Enable("github.com/pingcap/tidb-lightning/lightning/backend/GetRlimitValue", "return(16384)")
 	defer failpoint.Disable("github.com/pingcap/tidb-lightning/lightning/backend/GetRlimitValue")
 	c.Assert(err, IsNil)
 	err = checkSystemRequirement(cfg, dbMetas)

--- a/lightning/lightning_test.go
+++ b/lightning/lightning_test.go
@@ -427,6 +427,7 @@ func (s *lightningServerSuite) TestCheckSystemRequirement(c *C) {
 	}
 
 	cfg := config.NewConfig()
+	cfg.App.CheckRequirements = true
 	cfg.App.TableConcurrency = 4
 	cfg.TikvImporter.Backend = config.BackendLocal
 
@@ -475,6 +476,13 @@ func (s *lightningServerSuite) TestCheckSystemRequirement(c *C) {
 	// with this dbMetas, the estimated fds will be 2050, so should return error
 	err = checkSystemRequirement(cfg, dbMetas)
 	c.Assert(err, NotNil)
+
+	//disable check-requirement, should return nil
+	cfg.App.CheckRequirements = false
+	err = checkSystemRequirement(cfg, dbMetas)
+	c.Assert(err, IsNil)
+	cfg.App.CheckRequirements = true
+
 	err = failpoint.Disable("github.com/pingcap/tidb-lightning/lightning/backend/GetRlimitValue")
 	c.Assert(err, IsNil)
 

--- a/lightning/lightning_test.go
+++ b/lightning/lightning_test.go
@@ -466,20 +466,20 @@ func (s *lightningServerSuite) TestCheckSystemRequirement(c *C) {
 		},
 	}
 
-	// with max open files 1024, the max table size will be: 524288MB
-	err := failpoint.Enable("github.com/pingcap/tidb-lightning/lightning/backend/GetRlimitValue", "return(1024)")
+	// with max open files 2048, the max table size will be: 524288MB
+	err := failpoint.Enable("github.com/pingcap/tidb-lightning/lightning/backend/GetRlimitValue", "return(2049)")
 	c.Assert(err, IsNil)
 	err = failpoint.Enable("github.com/pingcap/tidb-lightning/lightning/backend/SetRlimitError", "return(true)")
 	c.Assert(err, IsNil)
 	defer failpoint.Disable("github.com/pingcap/tidb-lightning/lightning/backend/SetRlimitError")
-	// with this dbMetas, the estimated fds will be 1025, so should return error
+	// with this dbMetas, the estimated fds will be 2050, so should return error
 	err = checkSystemRequirement(cfg, dbMetas)
 	c.Assert(err, NotNil)
 	err = failpoint.Disable("github.com/pingcap/tidb-lightning/lightning/backend/GetRlimitValue")
 	c.Assert(err, IsNil)
 
 	// the min rlimit should be bigger than the default min value (16384)
-	err = failpoint.Enable("github.com/pingcap/tidb-lightning/lightning/backend/GetRlimitValue", "return(16384)")
+	err = failpoint.Enable("github.com/pingcap/tidb-lightning/lightning/backend/GetRlimitValue", "return(2050)")
 	defer failpoint.Disable("github.com/pingcap/tidb-lightning/lightning/backend/GetRlimitValue")
 	c.Assert(err, IsNil)
 	err = checkSystemRequirement(cfg, dbMetas)

--- a/lightning/restore/restore.go
+++ b/lightning/restore/restore.go
@@ -210,9 +210,20 @@ func NewRestoreControllerWithPauser(
 		}
 		backend = kv.NewTiDBBackend(db, cfg.TikvImporter.OnDuplicate)
 	case config.BackendLocal:
+		var rLimit uint64
+		rLimit, err = kv.GetSystemRLimit()
+		if err != nil {
+			return nil, err
+		}
+		maxOpenFiles := int(rLimit / uint64(cfg.App.TableConcurrency))
+		// check overflow
+		if maxOpenFiles < 0 {
+			maxOpenFiles = math.MaxInt32
+		}
+
 		backend, err = kv.NewLocalBackend(ctx, tls, cfg.TiDB.PdAddr, int64(cfg.TikvImporter.RegionSplitSize),
 			cfg.TikvImporter.SortedKVDir, cfg.TikvImporter.RangeConcurrency, cfg.TikvImporter.SendKVPairs,
-			cfg.Checkpoint.Enable, g)
+			cfg.Checkpoint.Enable, g, maxOpenFiles)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-Lightning! Please read the [CONTRIBUTING](https://github.com/pingcap/tidb-lightning/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Set the maximum open file limit for pebble to avoid open files exceeds the system open files limit

### What is changed and how it works?
- set the estimated max open files limit to (sum of topN table files size) / tableConcurrency * 2
- check the estimated open files limit with a default min value of 1024. 
- Set pebble maxOpenFiles to the estimatedOpenFiles, L0CompactionThreshold and L0StopWritesThreshold to estimatedOpenFiles/2.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

Side effects

 - Possible performance regression
   - Since if there are more files in pebble than estimatedOpenFiles/2, pebble will start compacting L0 SST files and stop write, thus there may be performance regression in some extreme condition
 - Increased code complexity

Related changes
