### PR TITLE
backend: support stored generated columns in local/importer backends

### DIFF
--- a/lightning/backend/backend.go
+++ b/lightning/backend/backend.go
@@ -104,7 +104,7 @@ type AbstractBackend interface {
 	ShouldPostProcess() bool
 
 	// NewEncoder creates an encoder of a TiDB table.
-	NewEncoder(tbl table.Table, options *SessionOptions) Encoder
+	NewEncoder(tbl table.Table, options *SessionOptions) (Encoder, error)
 
 	OpenEngine(ctx context.Context, engineUUID uuid.UUID) error
 
@@ -196,7 +196,7 @@ func (be Backend) MakeEmptyRows() Rows {
 	return be.abstract.MakeEmptyRows()
 }
 
-func (be Backend) NewEncoder(tbl table.Table, options *SessionOptions) Encoder {
+func (be Backend) NewEncoder(tbl table.Table, options *SessionOptions) (Encoder, error) {
 	return be.abstract.NewEncoder(tbl, options)
 }
 

--- a/lightning/backend/backend_test.go
+++ b/lightning/backend/backend_test.go
@@ -322,7 +322,9 @@ func (s *backendSuite) TestNewEncoder(c *C) {
 
 	encoder := mock.NewMockEncoder(s.controller)
 	options := &kv.SessionOptions{SQLMode: mysql.ModeANSIQuotes, Timestamp: 1234567890, RowFormatVersion: "1"}
-	s.mockBackend.EXPECT().NewEncoder(nil, options).Return(encoder)
+	s.mockBackend.EXPECT().NewEncoder(nil, options).Return(encoder, nil)
 
-	c.Assert(s.mockBackend.NewEncoder(nil, options), Equals, encoder)
+	realEncoder, err := s.mockBackend.NewEncoder(nil, options)
+	c.Assert(realEncoder, Equals, encoder)
+	c.Assert(err, IsNil)
 }

--- a/lightning/backend/importer.go
+++ b/lightning/backend/importer.go
@@ -237,7 +237,7 @@ func (*importer) MakeEmptyRows() Rows {
 	return kvPairs(nil)
 }
 
-func (*importer) NewEncoder(tbl table.Table, options *SessionOptions) Encoder {
+func (*importer) NewEncoder(tbl table.Table, options *SessionOptions) (Encoder, error) {
 	return NewTableKVEncoder(tbl, options)
 }
 

--- a/lightning/backend/local.go
+++ b/lightning/backend/local.go
@@ -1203,7 +1203,7 @@ func (local *local) MakeEmptyRows() Rows {
 	return kvPairs(nil)
 }
 
-func (local *local) NewEncoder(tbl table.Table, options *SessionOptions) Encoder {
+func (local *local) NewEncoder(tbl table.Table, options *SessionOptions) (Encoder, error) {
 	return NewTableKVEncoder(tbl, options)
 }
 

--- a/lightning/backend/session.go
+++ b/lightning/backend/session.go
@@ -197,6 +197,7 @@ func newSession(options *SessionOptions) *session {
 	vars.StmtCtx.TimeZone = vars.Location()
 	vars.SetSystemVar("timestamp", strconv.FormatInt(options.Timestamp, 10))
 	vars.SetSystemVar(variable.TiDBRowFormatVersion, options.RowFormatVersion)
+	vars.SetSystemVar(variable.MaxAllowedPacket, strconv.FormatUint(variable.MaxOfMaxAllowedPacket, 10))
 	vars.TxnCtx = nil
 
 	s := &session{

--- a/lightning/backend/sql2kv_test.go
+++ b/lightning/backend/sql2kv_test.go
@@ -83,11 +83,12 @@ func (s *kvSuite) TestEncode(c *C) {
 	}
 
 	// Strict mode
-	strictMode := NewTableKVEncoder(tbl, &SessionOptions{
+	strictMode, err := NewTableKVEncoder(tbl, &SessionOptions{
 		SQLMode:          mysql.ModeStrictAllTables,
 		Timestamp:        1234567890,
 		RowFormatVersion: "1",
 	})
+	c.Assert(err, IsNil)
 	pairs, err := strictMode.Encode(logger, rows, 1, []int{0, 1})
 	c.Assert(err, ErrorMatches, "failed to cast `10000000` as tinyint\\(4\\) for column `c1` \\(#1\\):.*overflows tinyint")
 	c.Assert(pairs, IsNil)
@@ -114,20 +115,22 @@ func (s *kvSuite) TestEncode(c *C) {
 
 	// Mock add record error
 	mockTbl := &mockTable{Table: tbl}
-	mockMode := NewTableKVEncoder(mockTbl, &SessionOptions{
+	mockMode, err := NewTableKVEncoder(mockTbl, &SessionOptions{
 		SQLMode:          mysql.ModeStrictAllTables,
 		Timestamp:        1234567891,
 		RowFormatVersion: "1",
 	})
+	c.Assert(err, IsNil)
 	pairs, err = mockMode.Encode(logger, rowsWithPk2, 2, []int{0, 1})
 	c.Assert(err, ErrorMatches, "mock error")
 
 	// Non-strict mode
-	noneMode := NewTableKVEncoder(tbl, &SessionOptions{
+	noneMode, err := NewTableKVEncoder(tbl, &SessionOptions{
 		SQLMode:          mysql.ModeNone,
 		Timestamp:        1234567892,
 		RowFormatVersion: "1",
 	})
+	c.Assert(err, IsNil)
 	pairs, err = noneMode.Encode(logger, rows, 1, []int{0, 1})
 	c.Assert(err, IsNil)
 	c.Assert(pairs, DeepEquals, kvPairs([]common.KvPair{
@@ -152,11 +155,12 @@ func (s *kvSuite) TestEncodeRowFormatV2(c *C) {
 		types.NewIntDatum(10000000),
 	}
 
-	noneMode := NewTableKVEncoder(tbl, &SessionOptions{
+	noneMode, err := NewTableKVEncoder(tbl, &SessionOptions{
 		SQLMode:          mysql.ModeNone,
 		Timestamp:        1234567892,
 		RowFormatVersion: "2",
 	})
+	c.Assert(err, IsNil)
 	pairs, err := noneMode.Encode(logger, rows, 1, []int{0, 1})
 	c.Assert(err, IsNil)
 	c.Assert(pairs, DeepEquals, kvPairs([]common.KvPair{
@@ -196,11 +200,12 @@ func (s *kvSuite) TestEncodeTimestamp(c *C) {
 	logger := log.Logger{Logger: zap.NewNop()}
 
 	timeutil.SetSystemTZ("Etc/GMT-8") // force timezone to be UTC+08:00.
-	encoder := NewTableKVEncoder(tbl, &SessionOptions{
+	encoder, err := NewTableKVEncoder(tbl, &SessionOptions{
 		SQLMode:          mysql.ModeStrictAllTables,
 		Timestamp:        1234567893,
 		RowFormatVersion: "1",
 	})
+	c.Assert(err, IsNil)
 	pairs, err := encoder.Encode(logger, nil, 70, []int{-1, 1})
 	c.Assert(err, IsNil)
 	c.Assert(pairs, DeepEquals, kvPairs([]common.KvPair{
@@ -228,12 +233,13 @@ func (s *kvSuite) TestDefaultAutoRandoms(c *C) {
 	tblInfo.AutoRandomBits = 5
 	tbl, err := tables.TableFromMeta(NewPanickingAllocators(0), tblInfo)
 	c.Assert(err, IsNil)
-	encoder := NewTableKVEncoder(tbl, &SessionOptions{
+	encoder, err := NewTableKVEncoder(tbl, &SessionOptions{
 		SQLMode:          mysql.ModeStrictAllTables,
 		Timestamp:        1234567893,
 		RowFormatVersion: "2",
 		AutoRandomSeed:   456,
 	})
+	c.Assert(err, IsNil)
 	logger := log.Logger{Logger: zap.NewNop()}
 	pairs, err := encoder.Encode(logger, []types.Datum{types.NewStringDatum("")}, 70, []int{-1, 0})
 	c.Assert(err, IsNil)
@@ -393,7 +399,8 @@ func (s *benchSQL2KVSuite) SetUpTest(c *C) {
 	// Construct the corresponding KV encoder.
 	tbl, err := tables.TableFromMeta(NewPanickingAllocators(0), tableInfo)
 	c.Assert(err, IsNil)
-	s.encoder = NewTableKVEncoder(tbl, &SessionOptions{RowFormatVersion: "2"})
+	s.encoder, err = NewTableKVEncoder(tbl, &SessionOptions{RowFormatVersion: "2"})
+	c.Assert(err, IsNil)
 	s.logger = log.Logger{Logger: zap.NewNop()}
 
 	// Prepare the row to insert.

--- a/lightning/backend/tidb.go
+++ b/lightning/backend/tidb.go
@@ -290,14 +290,14 @@ func (be *tidbBackend) CheckRequirements(ctx context.Context) error {
 	return nil
 }
 
-func (be *tidbBackend) NewEncoder(tbl table.Table, options *SessionOptions) Encoder {
+func (be *tidbBackend) NewEncoder(tbl table.Table, options *SessionOptions) (Encoder, error) {
 	se := newSession(options)
 	if options.SQLMode.HasStrictMode() {
 		se.vars.SkipUTF8Check = false
 		se.vars.SkipASCIICheck = false
 	}
 
-	return &tidbEncoder{mode: options.SQLMode, tbl: tbl, se: se}
+	return &tidbEncoder{mode: options.SQLMode, tbl: tbl, se: se}, nil
 }
 
 func (be *tidbBackend) OpenEngine(context.Context, uuid.UUID) error {

--- a/lightning/backend/tidb_test.go
+++ b/lightning/backend/tidb_test.go
@@ -91,7 +91,8 @@ func (s *mysqlSuite) TestWriteRowsReplaceOnDup(c *C) {
 		perms = append(perms, i)
 	}
 	perms = append(perms, -1)
-	encoder := s.backend.NewEncoder(s.tbl, &kv.SessionOptions{SQLMode: 0, Timestamp: 1234567890, RowFormatVersion: "1"})
+	encoder, err := s.backend.NewEncoder(s.tbl, &kv.SessionOptions{SQLMode: 0, Timestamp: 1234567890, RowFormatVersion: "1"})
+	c.Assert(err, IsNil)
 	row, err := encoder.Encode(logger, []types.Datum{
 		types.NewUintDatum(18446744073709551615),
 		types.NewIntDatum(-9223372036854775808),
@@ -131,7 +132,8 @@ func (s *mysqlSuite) TestWriteRowsIgnoreOnDup(c *C) {
 	indexRows := ignoreBackend.MakeEmptyRows()
 	indexChecksum := verification.MakeKVChecksum(0, 0, 0)
 
-	encoder := ignoreBackend.NewEncoder(s.tbl, &kv.SessionOptions{})
+	encoder, err := ignoreBackend.NewEncoder(s.tbl, &kv.SessionOptions{})
+	c.Assert(err, IsNil)
 	row, err := encoder.Encode(logger, []types.Datum{
 		types.NewIntDatum(1),
 	}, 1, []int{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, -1})
@@ -159,7 +161,8 @@ func (s *mysqlSuite) TestWriteRowsErrorOnDup(c *C) {
 	indexRows := ignoreBackend.MakeEmptyRows()
 	indexChecksum := verification.MakeKVChecksum(0, 0, 0)
 
-	encoder := ignoreBackend.NewEncoder(s.tbl, &kv.SessionOptions{})
+	encoder, err := ignoreBackend.NewEncoder(s.tbl, &kv.SessionOptions{})
+	c.Assert(err, IsNil)
 	row, err := encoder.Encode(logger, []types.Datum{
 		types.NewIntDatum(1),
 	}, 1, []int{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, -1})
@@ -183,7 +186,8 @@ func (s *mysqlSuite) TestStrictMode(c *C) {
 	c.Assert(err, IsNil)
 
 	bk := kv.NewTiDBBackend(s.dbHandle, config.ErrorOnDup)
-	encoder := bk.NewEncoder(tbl, &kv.SessionOptions{SQLMode: mysql.ModeStrictAllTables})
+	encoder, err := bk.NewEncoder(tbl, &kv.SessionOptions{SQLMode: mysql.ModeStrictAllTables})
+	c.Assert(err, IsNil)
 
 	logger := log.L()
 	_, err = encoder.Encode(logger, []types.Datum{

--- a/lightning/restore/restore.go
+++ b/lightning/restore/restore.go
@@ -1585,10 +1585,12 @@ func (t *TableRestore) parseColumnPermutations(columns []string) ([]int, error) 
 		if i, ok := columnMap[colInfo.Name.L]; ok {
 			colPerm = append(colPerm, i)
 		} else {
-			t.logger.Warn("column missing from data file, going to fill with default value",
-				zap.String("colName", colInfo.Name.O),
-				zap.Stringer("colType", &colInfo.FieldType),
-			)
+			if len(colInfo.GeneratedExprString) == 0 {
+				t.logger.Warn("column missing from data file, going to fill with default value",
+					zap.String("colName", colInfo.Name.O),
+					zap.Stringer("colType", &colInfo.FieldType),
+				)
+			}
 			colPerm = append(colPerm, -1)
 		}
 	}
@@ -1925,13 +1927,17 @@ func (cr *chunkRestore) restore(
 	rc *RestoreController,
 ) error {
 	// Create the encoder.
-	kvEncoder := rc.backend.NewEncoder(t.encTable, &kv.SessionOptions{
+	kvEncoder, err := rc.backend.NewEncoder(t.encTable, &kv.SessionOptions{
 		SQLMode:          rc.cfg.TiDB.SQLMode,
 		Timestamp:        cr.chunk.Timestamp,
 		RowFormatVersion: rc.rowFormatVer,
 		// use chunk.PrevRowIDMax as the auto random seed, so it can stay the same value after recover from checkpoint.
 		AutoRandomSeed: cr.chunk.Chunk.PrevRowIDMax,
 	})
+	if err != nil {
+		return err
+	}
+
 	kvsCh := make(chan []deliveredKVs, maxKVQueueSize)
 	deliverCompleteCh := make(chan deliverResult)
 

--- a/mock/backend.go
+++ b/mock/backend.go
@@ -8,18 +8,16 @@ package mock
 
 import (
 	context "context"
-	reflect "reflect"
-	time "time"
-
 	gomock "github.com/golang/mock/gomock"
 	uuid "github.com/google/uuid"
 	model "github.com/pingcap/parser/model"
-	table "github.com/pingcap/tidb/table"
-	types "github.com/pingcap/tidb/types"
-
 	backend "github.com/pingcap/tidb-lightning/lightning/backend"
 	log "github.com/pingcap/tidb-lightning/lightning/log"
 	verification "github.com/pingcap/tidb-lightning/lightning/verification"
+	table "github.com/pingcap/tidb/table"
+	types "github.com/pingcap/tidb/types"
+	reflect "reflect"
+	time "time"
 )
 
 // MockBackend is a mock of AbstractBackend interface
@@ -157,11 +155,12 @@ func (mr *MockBackendMockRecorder) MaxChunkSize() *gomock.Call {
 }
 
 // NewEncoder mocks base method
-func (m *MockBackend) NewEncoder(arg0 table.Table, arg1 *backend.SessionOptions) backend.Encoder {
+func (m *MockBackend) NewEncoder(arg0 table.Table, arg1 *backend.SessionOptions) (backend.Encoder, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "NewEncoder", arg0, arg1)
 	ret0, _ := ret[0].(backend.Encoder)
-	return ret0
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // NewEncoder indicates an expected call of NewEncoder

--- a/tests/_utils/run_sql
+++ b/tests/_utils/run_sql
@@ -16,7 +16,7 @@
 set -eu
 TEST_DIR=/tmp/lightning_test_result
 
-echo "[$(date)] Executing SQL: $1" > "$TEST_DIR/sql_res.$TEST_NAME.txt"
+echo "[$(date)] Executing SQL: ${*: -1:1}" > "$TEST_DIR/sql_res.$TEST_NAME.txt"
 mysql -uroot -h127.0.0.1 -P4000 \
     --ssl-ca="$TEST_DIR/tls/ca.pem" \
     --ssl-cert="$TEST_DIR/tls/curl.pem" \

--- a/tests/generated_columns/data/gencol-schema-create.sql
+++ b/tests/generated_columns/data/gencol-schema-create.sql
@@ -1,0 +1,1 @@
+create schema gencol;

--- a/tests/generated_columns/data/gencol.nested-schema.sql
+++ b/tests/generated_columns/data/gencol.nested-schema.sql
@@ -1,0 +1,7 @@
+create table nested (
+    a int not null primary key,
+    b int as (a + 1) virtual unique,
+    c int as (b + 1) stored unique,
+    d int as (c + 1) virtual unique,
+    e int as (d + 1) stored unique
+);

--- a/tests/generated_columns/data/gencol.nested.0.sql
+++ b/tests/generated_columns/data/gencol.nested.0.sql
@@ -1,0 +1,1 @@
+insert into nested (a) values (1), (10), (100), (1000);

--- a/tests/generated_columns/data/gencol.various_types-schema.sql
+++ b/tests/generated_columns/data/gencol.various_types-schema.sql
@@ -1,0 +1,15 @@
+create table various_types (
+    int64 bigint as (1 + 2) stored,
+    uint64 bigint unsigned as (pow(7, 8)) stored, -- 5764801
+    float32 float as (9 / 16) stored,
+    float64 double as (5e222) stored,
+    string text as (sha1(repeat('x', uint64))) stored, -- '6ad8402ba6610f04d3ec5c9875489a7bc8e259c5'
+    bytes blob as (unhex(string)) stored,
+    `decimal` decimal(8, 4) as (1234.5678) stored,
+    duration time as ('1:2:3') stored,
+    enum enum('a','b','c') as ('c') stored,
+    bit bit(4) as (int64) stored,
+    `set` set('a','b','c') as (enum) stored,
+    time timestamp(3) as ('1987-06-05 04:03:02.100') stored,
+    json json as (json_object(string, float32)) stored
+);

--- a/tests/generated_columns/data/gencol.various_types.0.sql
+++ b/tests/generated_columns/data/gencol.various_types.0.sql
@@ -1,0 +1,1 @@
+insert into various_types () values ();

--- a/tests/generated_columns/run.sh
+++ b/tests/generated_columns/run.sh
@@ -1,0 +1,48 @@
+#!/bin/sh
+#
+# Copyright 2020 PingCAP, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -eu
+
+for BACKEND in 'tidb' 'importer' 'local'; do
+    if [ "$BACKEND" = 'local' ]; then
+        check_cluster_version 4 0 0 'local backend' || continue
+    fi
+
+    run_sql 'DROP DATABASE IF EXISTS gencol'
+
+    run_lightning --backend $BACKEND
+
+    run_sql 'SELECT * FROM gencol.nested WHERE a = 100'
+    check_contains 'a: 100'
+    check_contains 'b: 101'
+    check_contains 'c: 102'
+    check_contains 'd: 103'
+    check_contains 'e: 104'
+
+    run_sql --binary-as-hex 'SELECT * FROM gencol.various_types'
+    check_contains 'int64: 3'
+    check_contains 'uint64: 5764801'
+    check_contains 'float32: 0.5625'
+    check_contains 'float64: 5e222'
+    check_contains 'string: 6ad8402ba6610f04d3ec5c9875489a7bc8e259c5'
+    check_contains 'bytes: 0x6AD8402BA6610F04D3EC5C9875489A7BC8E259C5'
+    check_contains 'decimal: 1234.5678'
+    check_contains 'duration: 01:02:03'
+    check_contains 'enum: c'
+    check_contains 'bit: 0x03'
+    check_contains 'set: c'
+    check_contains 'time: 1987-06-05 04:03:02.100'
+    check_contains 'json: {"6ad8402ba6610f04d3ec5c9875489a7bc8e259c5": 0.5625}'
+done

--- a/tests/restore/run.sh
+++ b/tests/restore/run.sh
@@ -28,7 +28,7 @@ done
 
 # Count OpenEngine and CloseEngine events.
 # Abort if number of unbalanced OpenEngine is >= 4
-export GO_FAILPOINTS='github.com/pingcap/tidb-lightning/lightning/kv/FailIfEngineCountExceeds=return(4)'
+export GO_FAILPOINTS='github.com/pingcap/tidb-lightning/lightning/backend/FailIfEngineCountExceeds=return(4)'
 
 # Start importing
 run_sql 'DROP DATABASE IF EXISTS restore_tsr'


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-Lightning! Please read the [CONTRIBUTING](https://github.com/pingcap/tidb-lightning/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Properly support stored generated columns in local/importer backends.

Unlike virtual generated columns, the value of stored generated columns are saved into the KV entries. This is computed before `AddRecord()`. Therefore, before this PR, all stored generated columns imported using local or importer backends become NULL.

### What is changed and how it works?

We now fill in the stored generated columns by evaluating their expressions. 

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Integration test

Side effects

 - Increased code complexity

Related changes

# Release notes

Fixed: In local and importer backends, stored generated columns are properly filled in instead of being NULL.