### PR TITLE
backend,restore: duplicate more important system variables from downstream

### DIFF
--- a/lightning/backend/backend_test.go
+++ b/lightning/backend/backend_test.go
@@ -321,7 +321,7 @@ func (s *backendSuite) TestNewEncoder(c *C) {
 	defer s.tearDownTest()
 
 	encoder := mock.NewMockEncoder(s.controller)
-	options := &kv.SessionOptions{SQLMode: mysql.ModeANSIQuotes, Timestamp: 1234567890, RowFormatVersion: "1"}
+	options := &kv.SessionOptions{SQLMode: mysql.ModeANSIQuotes, Timestamp: 1234567890}
 	s.mockBackend.EXPECT().NewEncoder(nil, options).Return(encoder)
 
 	c.Assert(s.mockBackend.NewEncoder(nil, options), Equals, encoder)

--- a/lightning/backend/session.go
+++ b/lightning/backend/session.go
@@ -199,6 +199,7 @@ func newSession(options *SessionOptions) *session {
 			vars.SetSystemVar(k, v)
 		}
 	}
+	vars.StmtCtx.TimeZone = vars.Location()
 	vars.SetSystemVar("timestamp", strconv.FormatInt(options.Timestamp, 10))
 	vars.TxnCtx = nil
 

--- a/lightning/backend/session.go
+++ b/lightning/backend/session.go
@@ -176,9 +176,9 @@ type session struct {
 
 // SessionOptions is the initial configuration of the session.
 type SessionOptions struct {
-	SQLMode          mysql.SQLMode
-	Timestamp        int64
-	RowFormatVersion string
+	SQLMode   mysql.SQLMode
+	Timestamp int64
+	SysVars   map[string]string
 	// a seed used for tableKvEncoder's auto random bits value
 	AutoRandomSeed int64
 }
@@ -194,9 +194,12 @@ func newSession(options *SessionOptions) *session {
 	vars.StmtCtx.OverflowAsWarning = !sqlMode.HasStrictMode()
 	vars.StmtCtx.AllowInvalidDate = sqlMode.HasAllowInvalidDatesMode()
 	vars.StmtCtx.IgnoreZeroInDate = !sqlMode.HasStrictMode() || sqlMode.HasAllowInvalidDatesMode()
-	vars.StmtCtx.TimeZone = vars.Location()
+	if options.SysVars != nil {
+		for k, v := range options.SysVars {
+			vars.SetSystemVar(k, v)
+		}
+	}
 	vars.SetSystemVar("timestamp", strconv.FormatInt(options.Timestamp, 10))
-	vars.SetSystemVar(variable.TiDBRowFormatVersion, options.RowFormatVersion)
 	vars.TxnCtx = nil
 
 	s := &session{

--- a/lightning/backend/session_test.go
+++ b/lightning/backend/session_test.go
@@ -30,7 +30,7 @@ func TestKV(t *testing.T) {
 }
 
 func (s *kvSuite) TestSetOption(c *C) {
-	session := newSession(&SessionOptions{SQLMode: mysql.ModeNone, Timestamp: 1234567890, RowFormatVersion: "1"})
+	session := newSession(&SessionOptions{SQLMode: mysql.ModeNone, Timestamp: 1234567890})
 	txn, err := session.Txn(true)
 	c.Assert(err, IsNil)
 	txn.SetOption(tidbkv.Priority, tidbkv.PriorityHigh)

--- a/lightning/backend/sql2kv.go
+++ b/lightning/backend/sql2kv.go
@@ -157,7 +157,7 @@ func collectGeneratedColumns(se *session, meta *model.TableInfo, cols []*table.C
 
 	// order the result by column offset so they match the evaluation order.
 	sort.Slice(genCols, func(i, j int) bool {
-		return cols[i].Offset < cols[j].Offset
+		return cols[genCols[i].index].Offset < cols[genCols[j].index].Offset
 	})
 	return genCols, nil
 }

--- a/lightning/backend/sql2kv_test.go
+++ b/lightning/backend/sql2kv_test.go
@@ -29,7 +29,6 @@ import (
 	"github.com/pingcap/tidb/table/tables"
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/util/mock"
-	"github.com/pingcap/tidb/util/timeutil"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 
@@ -84,9 +83,8 @@ func (s *kvSuite) TestEncode(c *C) {
 
 	// Strict mode
 	strictMode := NewTableKVEncoder(tbl, &SessionOptions{
-		SQLMode:          mysql.ModeStrictAllTables,
-		Timestamp:        1234567890,
-		RowFormatVersion: "1",
+		SQLMode:   mysql.ModeStrictAllTables,
+		Timestamp: 1234567890,
 	})
 	pairs, err := strictMode.Encode(logger, rows, 1, []int{0, 1})
 	c.Assert(err, ErrorMatches, "failed to cast `10000000` as tinyint\\(4\\) for column `c1` \\(#1\\):.*overflows tinyint")
@@ -115,18 +113,17 @@ func (s *kvSuite) TestEncode(c *C) {
 	// Mock add record error
 	mockTbl := &mockTable{Table: tbl}
 	mockMode := NewTableKVEncoder(mockTbl, &SessionOptions{
-		SQLMode:          mysql.ModeStrictAllTables,
-		Timestamp:        1234567891,
-		RowFormatVersion: "1",
+		SQLMode:   mysql.ModeStrictAllTables,
+		Timestamp: 1234567891,
 	})
 	pairs, err = mockMode.Encode(logger, rowsWithPk2, 2, []int{0, 1})
 	c.Assert(err, ErrorMatches, "mock error")
 
 	// Non-strict mode
 	noneMode := NewTableKVEncoder(tbl, &SessionOptions{
-		SQLMode:          mysql.ModeNone,
-		Timestamp:        1234567892,
-		RowFormatVersion: "1",
+		SQLMode:   mysql.ModeNone,
+		Timestamp: 1234567892,
+		SysVars:   map[string]string{"tidb_row_format_version": "1"},
 	})
 	pairs, err = noneMode.Encode(logger, rows, 1, []int{0, 1})
 	c.Assert(err, IsNil)
@@ -153,9 +150,9 @@ func (s *kvSuite) TestEncodeRowFormatV2(c *C) {
 	}
 
 	noneMode := NewTableKVEncoder(tbl, &SessionOptions{
-		SQLMode:          mysql.ModeNone,
-		Timestamp:        1234567892,
-		RowFormatVersion: "2",
+		SQLMode:   mysql.ModeNone,
+		Timestamp: 1234567892,
+		SysVars:   map[string]string{"tidb_row_format_version": "2"},
 	})
 	pairs, err := noneMode.Encode(logger, rows, 1, []int{0, 1})
 	c.Assert(err, IsNil)
@@ -195,11 +192,13 @@ func (s *kvSuite) TestEncodeTimestamp(c *C) {
 
 	logger := log.Logger{Logger: zap.NewNop()}
 
-	timeutil.SetSystemTZ("Etc/GMT-8") // force timezone to be UTC+08:00.
 	encoder := NewTableKVEncoder(tbl, &SessionOptions{
-		SQLMode:          mysql.ModeStrictAllTables,
-		Timestamp:        1234567893,
-		RowFormatVersion: "1",
+		SQLMode:   mysql.ModeStrictAllTables,
+		Timestamp: 1234567893,
+		SysVars: map[string]string{
+			"tidb_row_format_version": "1",
+			"time_zone":               "+08:00",
+		},
 	})
 	pairs, err := encoder.Encode(logger, nil, 70, []int{-1, 1})
 	c.Assert(err, IsNil)
@@ -229,10 +228,10 @@ func (s *kvSuite) TestDefaultAutoRandoms(c *C) {
 	tbl, err := tables.TableFromMeta(NewPanickingAllocators(0), tblInfo)
 	c.Assert(err, IsNil)
 	encoder := NewTableKVEncoder(tbl, &SessionOptions{
-		SQLMode:          mysql.ModeStrictAllTables,
-		Timestamp:        1234567893,
-		RowFormatVersion: "2",
-		AutoRandomSeed:   456,
+		SQLMode:        mysql.ModeStrictAllTables,
+		Timestamp:      1234567893,
+		SysVars:        map[string]string{"tidb_row_format_version": "2"},
+		AutoRandomSeed: 456,
 	})
 	logger := log.Logger{Logger: zap.NewNop()}
 	pairs, err := encoder.Encode(logger, []types.Datum{types.NewStringDatum("")}, 70, []int{-1, 0})
@@ -393,7 +392,7 @@ func (s *benchSQL2KVSuite) SetUpTest(c *C) {
 	// Construct the corresponding KV encoder.
 	tbl, err := tables.TableFromMeta(NewPanickingAllocators(0), tableInfo)
 	c.Assert(err, IsNil)
-	s.encoder = NewTableKVEncoder(tbl, &SessionOptions{RowFormatVersion: "2"})
+	s.encoder = NewTableKVEncoder(tbl, &SessionOptions{SysVars: map[string]string{"tidb_row_format_version": "2"}})
 	s.logger = log.Logger{Logger: zap.NewNop()}
 
 	// Prepare the row to insert.

--- a/lightning/backend/tidb_test.go
+++ b/lightning/backend/tidb_test.go
@@ -91,7 +91,7 @@ func (s *mysqlSuite) TestWriteRowsReplaceOnDup(c *C) {
 		perms = append(perms, i)
 	}
 	perms = append(perms, -1)
-	encoder := s.backend.NewEncoder(s.tbl, &kv.SessionOptions{SQLMode: 0, Timestamp: 1234567890, RowFormatVersion: "1"})
+	encoder := s.backend.NewEncoder(s.tbl, &kv.SessionOptions{SQLMode: 0, Timestamp: 1234567890})
 	row, err := encoder.Encode(logger, []types.Datum{
 		types.NewUintDatum(18446744073709551615),
 		types.NewIntDatum(-9223372036854775808),

--- a/lightning/restore/restore.go
+++ b/lightning/restore/restore.go
@@ -145,7 +145,7 @@ type RestoreController struct {
 	postProcessLock sync.Mutex // a simple way to ensure post-processing is not concurrent without using complicated goroutines
 	alterTableLock  sync.Mutex
 	compactState    int32
-	rowFormatVer    string
+	sysVars         map[string]string
 	tls             *common.TLS
 
 	errorSummaries errorSummaries
@@ -230,7 +230,7 @@ func NewRestoreControllerWithPauser(
 		pauser:        pauser,
 		backend:       backend,
 		tidbGlue:      g,
-		rowFormatVer:  "1",
+		sysVars:       defaultImportantVariables,
 		tls:           tls,
 
 		errorSummaries:    makeErrorSummaries(log.L()),
@@ -362,7 +362,7 @@ func (rc *RestoreController) restoreSchema(ctx context.Context) error {
 
 	go rc.listenCheckpointUpdates()
 
-	rc.rowFormatVer = ObtainRowFormatVersion(ctx, rc.tidbGlue.GetSQLExecutor())
+	rc.sysVars = ObtainImportantVariables(ctx, rc.tidbGlue.GetSQLExecutor())
 
 	// Estimate the number of chunks for progress reporting
 	err = rc.estimateChunkCountIntoMetrics(ctx)
@@ -1926,9 +1926,9 @@ func (cr *chunkRestore) restore(
 ) error {
 	// Create the encoder.
 	kvEncoder := rc.backend.NewEncoder(t.encTable, &kv.SessionOptions{
-		SQLMode:          rc.cfg.TiDB.SQLMode,
-		Timestamp:        cr.chunk.Timestamp,
-		RowFormatVersion: rc.rowFormatVer,
+		SQLMode:   rc.cfg.TiDB.SQLMode,
+		Timestamp: cr.chunk.Timestamp,
+		SysVars:   rc.sysVars,
 		// use chunk.PrevRowIDMax as the auto random seed, so it can stay the same value after recover from checkpoint.
 		AutoRandomSeed: cr.chunk.Chunk.PrevRowIDMax,
 	})

--- a/lightning/restore/restore_test.go
+++ b/lightning/restore/restore_test.go
@@ -927,9 +927,8 @@ func (s *chunkRestoreSuite) TestEncodeLoop(c *C) {
 	kvsCh := make(chan []deliveredKVs, 2)
 	deliverCompleteCh := make(chan deliverResult)
 	kvEncoder := kv.NewTableKVEncoder(s.tr.encTable, &kv.SessionOptions{
-		SQLMode:          s.cfg.TiDB.SQLMode,
-		Timestamp:        1234567895,
-		RowFormatVersion: "1",
+		SQLMode:   s.cfg.TiDB.SQLMode,
+		Timestamp: 1234567895,
 	})
 	cfg := config.NewConfig()
 	rc := &RestoreController{pauser: DeliverPauser, cfg: cfg}
@@ -952,9 +951,8 @@ func (s *chunkRestoreSuite) TestEncodeLoopCanceled(c *C) {
 	kvsCh := make(chan []deliveredKVs)
 	deliverCompleteCh := make(chan deliverResult)
 	kvEncoder := kv.NewTableKVEncoder(s.tr.encTable, &kv.SessionOptions{
-		SQLMode:          s.cfg.TiDB.SQLMode,
-		Timestamp:        1234567896,
-		RowFormatVersion: "1",
+		SQLMode:   s.cfg.TiDB.SQLMode,
+		Timestamp: 1234567896,
 	})
 
 	go cancel()
@@ -970,9 +968,8 @@ func (s *chunkRestoreSuite) TestEncodeLoopForcedError(c *C) {
 	kvsCh := make(chan []deliveredKVs, 2)
 	deliverCompleteCh := make(chan deliverResult)
 	kvEncoder := kv.NewTableKVEncoder(s.tr.encTable, &kv.SessionOptions{
-		SQLMode:          s.cfg.TiDB.SQLMode,
-		Timestamp:        1234567897,
-		RowFormatVersion: "1",
+		SQLMode:   s.cfg.TiDB.SQLMode,
+		Timestamp: 1234567897,
 	})
 
 	// close the chunk so reading it will result in the "file already closed" error.
@@ -990,9 +987,8 @@ func (s *chunkRestoreSuite) TestEncodeLoopDeliverErrored(c *C) {
 	kvsCh := make(chan []deliveredKVs)
 	deliverCompleteCh := make(chan deliverResult)
 	kvEncoder := kv.NewTableKVEncoder(s.tr.encTable, &kv.SessionOptions{
-		SQLMode:          s.cfg.TiDB.SQLMode,
-		Timestamp:        1234567898,
-		RowFormatVersion: "1",
+		SQLMode:   s.cfg.TiDB.SQLMode,
+		Timestamp: 1234567898,
 	})
 
 	go func() {

--- a/lightning/restore/tidb.go
+++ b/lightning/restore/tidb.go
@@ -40,6 +40,22 @@ import (
 	"go.uber.org/zap"
 )
 
+var (
+	// defaultImportantVariables is used in ObtainImportantVariables to retrieve the system
+	// variables from downstream which may affect KV encode result. The values record the default
+	// values if missing.
+	defaultImportantVariables = map[string]string{
+		"tidb_row_format_version": "1",
+		"max_allowed_packet":      "67108864",
+		"div_precision_increment": "4",
+		"time_zone":               "SYSTEM",
+		"lc_time_names":           "en_US",
+		"default_week_format":     "0",
+		"block_encryption_mode":   "aes-128-ecb",
+		"group_concat_max_len":    "1024",
+	}
+)
+
 type TiDBManager struct {
 	db     *sql.DB
 	parser *parser.Parser
@@ -271,17 +287,37 @@ func UpdateGCLifeTime(ctx context.Context, db *sql.DB, gcLifeTime string) error 
 	)
 }
 
-func ObtainRowFormatVersion(ctx context.Context, g glue.SQLExecutor) string {
-	rowFormatVersion, err := g.ObtainStringWithLog(
-		ctx,
-		"SELECT @@tidb_row_format_version",
-		"obtain row format version",
-		log.L(),
-	)
-	if err != nil {
-		rowFormatVersion = "1"
+func ObtainImportantVariables(ctx context.Context, g glue.SQLExecutor) map[string]string {
+	var query strings.Builder
+	query.WriteString("SHOW VARIABLES WHERE Variable_name IN ('")
+	first := true
+	for k := range defaultImportantVariables {
+		if first {
+			first = false
+		} else {
+			query.WriteString("','")
+		}
+		query.WriteString(k)
 	}
-	return rowFormatVersion
+	query.WriteString("')")
+	kvs, err := g.QueryStringsWithLog(ctx, query.String(), "obtain system variables", log.L())
+	if err != nil {
+		// error is not fatal
+		log.L().Warn("obtain system variables failed, use default variables instead", log.ShortError(err))
+	}
+
+	// convert result into a map. fill in any missing variables with default values.
+	result := make(map[string]string, len(defaultImportantVariables))
+	for _, kv := range kvs {
+		result[kv[0]] = kv[1]
+	}
+	for k, defV := range defaultImportantVariables {
+		if _, ok := result[k]; !ok {
+			result[k] = defV
+		}
+	}
+
+	return result
 }
 
 func ObtainNewCollationEnabled(ctx context.Context, g glue.SQLExecutor) bool {

--- a/tests/_utils/read_result
+++ b/tests/_utils/read_result
@@ -1,0 +1,22 @@
+#!/bin/sh
+#
+# Copyright 2020 PingCAP, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Read the result of the last run_sql execution.
+# Requires the run_sql returning a single row and column and the column name has no spaces.
+
+set -eu
+TEST_DIR=/tmp/lightning_test_result
+
+tail -1 "$TEST_DIR/sql_res.$TEST_NAME.txt" | cut -d' ' -f 2-

--- a/tests/auto_random_default/run.sh
+++ b/tests/auto_random_default/run.sh
@@ -37,10 +37,12 @@ for backend in tidb importer local; do
       check_contains 'inc: 4'
       check_contains 'inc: 5'
       check_contains 'inc: 6'
+      NEXT_AUTO_RAND_VAL=7
     else
       check_contains 'inc: 25'
       check_contains 'inc: 26'
       check_contains 'inc: 27'
+      NEXT_AUTO_RAND_VAL=28
     fi
 
 
@@ -48,11 +50,9 @@ for backend in tidb importer local; do
     check_contains "count: 2"
 
     # auto random base is 4
+    run_sql "SELECT max(id & b'000001111111111111111111111111111111111111111111111111111111111') >= $NEXT_AUTO_RAND_VAL as ge FROM auto_random.t"
+    check_contains 'ge: 0'
     run_sql "INSERT INTO auto_random.t VALUES ();"
-    run_sql "SELECT id & b'000001111111111111111111111111111111111111111111111111111111111' as inc FROM auto_random.t"
-    if [ "$backend" = 'tidb' ]; then
-      check_contains 'inc: 2000001'
-    else
-      check_contains 'inc: 28'
-    fi
+    run_sql "SELECT max(id & b'000001111111111111111111111111111111111111111111111111111111111') >= $NEXT_AUTO_RAND_VAL as ge FROM auto_random.t"
+    check_contains 'ge: 1'
 done

--- a/tests/generated_columns/data/gencol.various_types-schema.sql
+++ b/tests/generated_columns/data/gencol.various_types-schema.sql
@@ -13,6 +13,7 @@ create table various_types (
     time timestamp(3) as ('1987-06-05 04:03:02.100') stored,
     json json as (json_object(string, float32)) stored,
     aes blob as (aes_encrypt(`decimal`, 'key', bytes)) stored, -- 0xA876B03CFC8AF93D22D19E2220BD2375, @@block_encryption_mode='aes-256-cbc'
-    week int as (week('2020-02-02')) stored, -- 6, @@default_week_format=4
+    -- FIXME: column below disabled due to pingcap/tidb#21510
+    -- week int as (week('2020-02-02')) stored, -- 6, @@default_week_format=4
     tz varchar(20) as (from_unixtime(1)) stored -- 1969-12-31 16:00:01, @@time_zone='-08:00'
 );

--- a/tests/generated_columns/data/gencol.various_types-schema.sql
+++ b/tests/generated_columns/data/gencol.various_types-schema.sql
@@ -11,5 +11,8 @@ create table various_types (
     bit bit(4) as (int64) stored,
     `set` set('a','b','c') as (enum) stored,
     time timestamp(3) as ('1987-06-05 04:03:02.100') stored,
-    json json as (json_object(string, float32)) stored
+    json json as (json_object(string, float32)) stored,
+    aes blob as (aes_encrypt(`decimal`, 'key', bytes)) stored, -- 0xA876B03CFC8AF93D22D19E2220BD2375, @@block_encryption_mode='aes-256-cbc'
+    week int as (week('2020-02-02')) stored, -- 6, @@default_week_format=4
+    tz varchar(20) as (from_unixtime(1)) stored -- 1969-12-31 16:00:01, @@time_zone='-08:00'
 );

--- a/tests/generated_columns/run.sh
+++ b/tests/generated_columns/run.sh
@@ -65,6 +65,7 @@ for BACKEND in 'local' 'tidb' 'importer'; do
     check_contains 'time: 1987-06-05 04:03:02.100'
     check_contains 'json: {"6ad8402ba6610f04d3ec5c9875489a7bc8e259c5": 0.5625}'
     check_contains 'aes: 0xA876B03CFC8AF93D22D19E2220BD2375'
-    check_contains 'week: 6'
+    # FIXME: test below disabled due to pingcap/tidb#21510
+    # check_contains 'week: 6'
     check_contains 'tz: 1969-12-31 16:00:01'
 done


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-Lightning! Please read the [CONTRIBUTING](https://github.com/pingcap/tidb-lightning/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Fix #504.

### What is changed and how it works?

Copy all sys vars that affects expression evaluation results in additional to `tidb_row_format_version`.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test (will add integration test after #505 is merged)

Side effects

Related changes

