### PR TITLE
backend/local: fix next key

### DIFF
--- a/tests/various_types/data/vt.precise_types-schema.sql
+++ b/tests/various_types/data/vt.precise_types-schema.sql
@@ -2,5 +2,5 @@ create table precise_types (
     a BIGINT UNSIGNED NOT NULL,
     b BIGINT NOT NULL,
     c DECIMAL(21,1) NOT NULL,
-    d DOUBLE(21,1) NOT NULL
+    d DOUBLE NOT NULL
 );

--- a/tests/various_types/run.sh
+++ b/tests/various_types/run.sh
@@ -108,6 +108,6 @@ for BACKEND in importer tidb local; do
   check_contains 'a: 18446744073709551614'
   check_contains 'b: -9223372036854775806'
   check_contains 'c: 99999999999999999999.0'
-  check_contains 'd: 18446744073709551616.0'
+  check_contains 'd: 1.8446744073709552e19'
 
 done


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-Lightning! Please read the [CONTRIBUTING](https://github.com/pingcap/tidb-lightning/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
in tikv release-4.0, tikv will force truncate all row keys, so our currently truncate key is not valid according to this logic. 
See: https://github.com/tikv/tikv/blob/f7f22f70e1585d7ca38a59ea30e774949160c3e8/components/raftstore/src/coprocessor/split_observer.rs#L36-L41

### What is changed and how it works?
If the key is a row key, use handle.Next() to generate the next key, else, append a 0x00 to the key otherwise.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - No code

Side effects

Related changes
