### PR TITLE
backend: import planner/core package to initialize expression.RewriteAstExpr

### DIFF
--- a/lightning/backend/sql2kv.go
+++ b/lightning/backend/sql2kv.go
@@ -31,6 +31,9 @@ import (
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 
+	// Import tidb/planner/core to initialize expression.RewriteAstExpr
+	_ "github.com/pingcap/tidb/planner/core"
+
 	"github.com/pingcap/tidb-lightning/lightning/common"
 	"github.com/pingcap/tidb-lightning/lightning/log"
 	"github.com/pingcap/tidb-lightning/lightning/metric"

--- a/lightning/restore/restore.go
+++ b/lightning/restore/restore.go
@@ -49,9 +49,6 @@ import (
 	verify "github.com/pingcap/tidb-lightning/lightning/verification"
 	"github.com/pingcap/tidb-lightning/lightning/web"
 	"github.com/pingcap/tidb-lightning/lightning/worker"
-
-	// TODO: remove this after https://github.com/pingcap/tidb/issues/21342 is fixed.
-	_ "github.com/pingcap/tidb/planner/core"
 )
 
 const (


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-Lightning! Please read the [CONTRIBUTING](https://github.com/pingcap/tidb-lightning/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
close https://github.com/pingcap/tidb/issues/21342
planner/core and expression package need to be imported together to initialized expression.RewriteAstExpr

### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

Side effects

 - Possible performance regression
 - Increased code complexity
 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation
 - Need to update the `tidb-ansible` repository
 - Need to be included in the release note