### PR TITLE
restore: fix error lost in create schema

### DIFF
--- a/lightning/restore/tidb.go
+++ b/lightning/restore/tidb.go
@@ -154,6 +154,7 @@ func InitSchema(ctx context.Context, g glue.Glue, database string, tablesSchema 
 
 	task := logger.Begin(zap.InfoLevel, "create tables")
 	var sqlCreateStmts []string
+loopCreate:
 	for tbl, sqlCreateTable := range tablesSchema {
 		task.Debug("create table", zap.String("schema", sqlCreateTable))
 
@@ -171,7 +172,7 @@ func InitSchema(ctx context.Context, g glue.Glue, database string, tablesSchema 
 				logger.With(zap.String("table", common.UniqueTable(database, tbl))),
 			)
 			if err != nil {
-				break
+				break loopCreate
 			}
 		}
 	}

--- a/lightning/restore/tidb.go
+++ b/lightning/restore/tidb.go
@@ -22,6 +22,7 @@ import (
 
 	tmysql "github.com/go-sql-driver/mysql"
 	"github.com/pingcap/errors"
+	"github.com/pingcap/failpoint"
 	"github.com/pingcap/parser"
 	"github.com/pingcap/parser/ast"
 	"github.com/pingcap/parser/format"
@@ -171,6 +172,9 @@ loopCreate:
 				"create table",
 				logger.With(zap.String("table", common.UniqueTable(database, tbl))),
 			)
+			failpoint.Inject("sqlCreateStmts", func() {
+				err = errors.Errorf("create %s failed", tbl)
+			})
 			if err != nil {
 				break loopCreate
 			}

--- a/lightning/restore/tidb.go
+++ b/lightning/restore/tidb.go
@@ -175,7 +175,6 @@ loopCreate:
 			)
 			failpoint.Inject("sqlCreateStmts", func() {
 				err = errors.Errorf("create %s failed", tbl)
-				failpoint.Return()
 			})
 			if err != nil {
 				break loopCreate

--- a/lightning/restore/tidb.go
+++ b/lightning/restore/tidb.go
@@ -22,7 +22,6 @@ import (
 
 	tmysql "github.com/go-sql-driver/mysql"
 	"github.com/pingcap/errors"
-	"github.com/pingcap/failpoint"
 	"github.com/pingcap/parser"
 	"github.com/pingcap/parser/ast"
 	"github.com/pingcap/parser/format"
@@ -173,9 +172,6 @@ loopCreate:
 				"create table",
 				logger.With(zap.String("table", common.UniqueTable(database, tbl))),
 			)
-			failpoint.Inject("sqlCreateStmts", func() {
-				err = errors.Errorf("create %s failed", tbl)
-			})
 			if err != nil {
 				break loopCreate
 			}

--- a/lightning/restore/tidb_test.go
+++ b/lightning/restore/tidb_test.go
@@ -240,7 +240,8 @@ func (s *tidbSuite) TestInitSchemaErrorLost(c *C) {
 		"t2": "create table t2 (a int primary key, b varchar(200));",
 	})
 	failpoint.Disable("github.com/pingcap/tidb-lightning/lightning/restore/sqlCreateStmts")
-	c.Assert(err, ErrorMatches, "create  failed")
+	// cannot predict which table will failed since map is unorder.
+	c.Assert(err, ErrorMatches, "create (.*) failed")
 }
 
 func (s *tidbSuite) TestInitSchemaUnsupportedSchemaError(c *C) {

--- a/lightning/restore/tidb_test.go
+++ b/lightning/restore/tidb_test.go
@@ -234,13 +234,13 @@ func (s *tidbSuite) TestInitSchemaErrorLost(c *C) {
 	s.mockDB.
 		ExpectClose()
 
-	failpoint.Enable("github.com/pingcap/tidb-lightning/lightning/restore/sqlCreateStmts", "return")
+	failpoint.Enable("github.com/pingcap/tidb-lightning/lightning/restore/sqlCreateStmts", "1*return")
 	err := InitSchema(ctx, s.tiGlue, "db", map[string]string{
 		"t1": "create table `t1` (a int);",
 		"t2": "create table t2 (a int primary key, b varchar(200));",
 	})
 	failpoint.Disable("github.com/pingcap/tidb-lightning/lightning/restore/sqlCreateStmts")
-	c.Assert(err, ErrorMatches, "create t1 failed")
+	c.Assert(err, ErrorMatches, "create  failed")
 }
 
 func (s *tidbSuite) TestInitSchemaUnsupportedSchemaError(c *C) {


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-Lightning! Please read the [CONTRIBUTING](https://github.com/pingcap/tidb-lightning/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Fix https://github.com/pingcap/tidb/issues/21827

### What is changed and how it works?
break create loop immediately when error encountered

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)


Related changes

 - Need to cherry-pick to the release branch

Release note:

- Fix the issue that lost create table error during multiple tables created.