### PR TITLE
restore: don't change TiDB config to support lightning via SQL

### DIFF
--- a/lightning/restore/checksum.go
+++ b/lightning/restore/checksum.go
@@ -75,6 +75,7 @@ func newChecksumManager(ctx context.Context, rc *RestoreController) (ChecksumMan
 			return nil, errors.Trace(err)
 		}
 
+		// TODO: make tikv.Driver{}.Open use arguments instead of global variables
 		if tlsOpt.CAPath != "" {
 			conf := tidbcfg.GetGlobalConfig()
 			conf.Security.ClusterSSLCA = tlsOpt.CAPath

--- a/lightning/restore/restore.go
+++ b/lightning/restore/restore.go
@@ -31,7 +31,6 @@ import (
 	sstpb "github.com/pingcap/kvproto/pkg/import_sstpb"
 	"github.com/pingcap/parser/model"
 	"github.com/pingcap/tidb-lightning/lightning/glue"
-	tidbcfg "github.com/pingcap/tidb/config"
 	"github.com/pingcap/tidb/meta/autoid"
 	"github.com/pingcap/tidb/table"
 	"github.com/pingcap/tidb/table/tables"
@@ -73,8 +72,6 @@ const (
 var DeliverPauser = common.NewPauser()
 
 func init() {
-	cfg := tidbcfg.GetGlobalConfig()
-	cfg.Log.SlowThreshold = 3000
 	// used in integration tests
 	failpoint.Inject("SetMinDeliverBytes", func(v failpoint.Value) {
 		minDeliverBytes = uint64(v.(int))


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-Lightning! Please read the [CONTRIBUTING](https://github.com/pingcap/tidb-lightning/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
after use lightning as library, `init()` changed TiDB's global configuration unexpected

### What is changed and how it works?
try removing usage of tidbcfg

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - pass original test

Side effects


Related changes
