### PR TITLE
config: change redact log parameter name

### DIFF
--- a/lightning/config/config.go
+++ b/lightning/config/config.go
@@ -280,6 +280,8 @@ type Security struct {
 	CAPath   string `toml:"ca-path" json:"ca-path"`
 	CertPath string `toml:"cert-path" json:"cert-path"`
 	KeyPath  string `toml:"key-path" json:"key-path"`
+	// RedactInfoLog indicates that whether enabling redact log
+	RedactInfoLog bool `toml:"redact-info-log" json:"redact-info-log"`
 }
 
 // RegistersMySQL registers (or deregisters) the TLS config with name "cluster"

--- a/lightning/config/global.go
+++ b/lightning/config/global.go
@@ -144,7 +144,7 @@ func LoadGlobalConfig(args []string, extraFlags func(*flag.FlagSet)) (*GlobalCon
 
 	logLevel := flagext.ChoiceVar(fs, "L", "", `log level: info, debug, warn, error, fatal (default info)`, "", "info", "debug", "warn", "warning", "error", "fatal")
 	logFilePath := fs.String("log-file", "", "log file path")
-	redactLog := fs.Bool("redact-log", false, "whether to redact sensitive info in log")
+	redactLog := fs.Bool("redact-info-log", false, "whether to redact sensitive info in log")
 	tidbHost := fs.String("tidb-host", "", "TiDB server host")
 	tidbPort := fs.Int("tidb-port", 0, "TiDB server port (default 4000)")
 	tidbUser := fs.String("tidb-user", "", "TiDB user name to connect")

--- a/lightning/config/global.go
+++ b/lightning/config/global.go
@@ -144,7 +144,6 @@ func LoadGlobalConfig(args []string, extraFlags func(*flag.FlagSet)) (*GlobalCon
 
 	logLevel := flagext.ChoiceVar(fs, "L", "", `log level: info, debug, warn, error, fatal (default info)`, "", "info", "debug", "warn", "warning", "error", "fatal")
 	logFilePath := fs.String("log-file", "", "log file path")
-	redactLog := fs.Bool("redact-info-log", false, "whether to redact sensitive info in log")
 	tidbHost := fs.String("tidb-host", "", "TiDB server host")
 	tidbPort := fs.Int("tidb-port", 0, "TiDB server port (default 4000)")
 	tidbUser := fs.String("tidb-user", "", "TiDB user name to connect")
@@ -163,6 +162,7 @@ func LoadGlobalConfig(args []string, extraFlags func(*flag.FlagSet)) (*GlobalCon
 	tlsCAPath := fs.String("ca", "", "CA certificate path for TLS connection")
 	tlsCertPath := fs.String("cert", "", "certificate path for TLS connection")
 	tlsKeyPath := fs.String("key", "", "private key path for TLS connection")
+	redactInfoLog := fs.Bool("redact-info-log", false, "whether to redact sensitive info in log")
 
 	statusAddr := fs.String("status-addr", "", "the Lightning server address")
 	serverMode := fs.Bool("server-mode", false, "start Lightning in server mode, wait for multiple tasks instead of starting immediately")
@@ -198,9 +198,6 @@ func LoadGlobalConfig(args []string, extraFlags func(*flag.FlagSet)) (*GlobalCon
 	}
 	if *logFilePath != "" {
 		cfg.App.Config.File = *logFilePath
-	}
-	if *redactLog {
-		cfg.App.Config.RedactLog = *redactLog
 	}
 	// "-" is a special config for log to stdout
 	if cfg.App.Config.File == "-" {
@@ -270,6 +267,9 @@ func LoadGlobalConfig(args []string, extraFlags func(*flag.FlagSet)) (*GlobalCon
 	}
 	if *tlsKeyPath != "" {
 		cfg.Security.KeyPath = *tlsKeyPath
+	}
+	if *redactInfoLog {
+		cfg.Security.RedactInfoLog = *redactInfoLog
 	}
 	if len(filter) > 0 {
 		cfg.Mydumper.Filter = filter

--- a/lightning/lightning.go
+++ b/lightning/lightning.go
@@ -81,6 +81,8 @@ func New(globalCfg *config.GlobalConfig) *Lightning {
 		log.L().Fatal("failed to load TLS certificates", zap.Error(err))
 	}
 
+	log.InitRedact(globalCfg.Security.RedactInfoLog)
+
 	ctx, shutdown := context.WithCancel(context.Background())
 	return &Lightning{
 		globalCfg: globalCfg,

--- a/lightning/log/log.go
+++ b/lightning/log/log.go
@@ -44,8 +44,6 @@ type Config struct {
 	FileMaxDays int `toml:"max-days" json:"max-days"`
 	// Maximum number of old log files to retain.
 	FileMaxBackups int `toml:"max-backups" json:"max-backups"`
-	// Redact sensitive logs during the whole process
-	RedactLog bool `toml:"redact-info-log" json:"redact-info-log"`
 }
 
 func (cfg *Config) Adjust() {
@@ -99,8 +97,6 @@ func InitLogger(cfg *Config, tidbLoglevel string) error {
 	// error itself.
 	appLogger = Logger{logger.WithOptions(zap.AddStacktrace(zap.DPanicLevel))}
 	appLevel = props.Level
-
-	InitRedact(cfg.RedactLog)
 
 	return nil
 }

--- a/lightning/log/log.go
+++ b/lightning/log/log.go
@@ -45,7 +45,7 @@ type Config struct {
 	// Maximum number of old log files to retain.
 	FileMaxBackups int `toml:"max-backups" json:"max-backups"`
 	// Redact sensitive logs during the whole process
-	RedactLog bool `toml:"redact-log" json:"redact-log"`
+	RedactLog bool `toml:"redact-info-log" json:"redact-info-log"`
 }
 
 func (cfg *Config) Adjust() {

--- a/tidb-lightning.toml
+++ b/tidb-lightning.toml
@@ -41,8 +41,6 @@ file = "tidb-lightning.log"
 max-size = 128 # MB
 max-days = 28
 max-backups = 14
-# If set to true, lightning will redact sensitive infomation in log.
-redact-info-log = false
 
 [security]
 # specifies certificates and keys for TLS connections within the cluster.
@@ -52,6 +50,8 @@ redact-info-log = false
 # cert-path = "/path/to/lightning.pem"
 # private key of this service.
 # key-path = "/path/to/lightning.key"
+# If set to true, lightning will redact sensitive infomation in log.
+# redact-info-log = false
 
 [checkpoint]
 # Whether to enable checkpoints.

--- a/tidb-lightning.toml
+++ b/tidb-lightning.toml
@@ -42,7 +42,7 @@ max-size = 128 # MB
 max-days = 28
 max-backups = 14
 # If set to true, lightning will redact sensitive infomation in log.
-redact-log = false
+redact-info-log = false
 
 [security]
 # specifies certificates and keys for TLS connections within the cluster.


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-Lightning! Please read the [CONTRIBUTING](https://github.com/pingcap/tidb-lightning/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
In https://github.com/pingcap/tidb-lightning/pull/538, we added the `redact-log` parameter.

The redact log parameter name is different from TiKV's and PD's.
https://github.com/tikv/tikv/blob/master/etc/config-template.toml#L846
In TiKV it's `redact-info-log` configuration in config file.
https://github.com/tikv/pd/blob/master/server/config/config.go#L1373
In PD it's `redact-info-log` configuration in config file.

### What is changed and how it works?
Change `redact-log` to `redact-info-log`.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

Side effects

 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation