### PR TITLE
backend/tidb: temporarily disable the strict-mode value check in tidb backend 

### DIFF
--- a/lightning/backend/local_test.go
+++ b/lightning/backend/local_test.go
@@ -17,13 +17,13 @@ import (
 	"bytes"
 	"context"
 	"encoding/binary"
-	"fmt"
-	"github.com/pingcap/tidb-lightning/lightning/common"
 	"math"
 	"math/rand"
 	"os"
 	"path/filepath"
 	"sort"
+
+	"github.com/pingcap/tidb-lightning/lightning/common"
 
 	"github.com/cockroachdb/pebble"
 	. "github.com/pingcap/check"
@@ -378,16 +378,13 @@ func testLocalWriter(c *C, needSort bool, partitialSort bool) {
 }
 
 func (s *localSuite) TestLocalWriterWithSort(c *C) {
-	fmt.Println("TestLocalWriterWithSort")
 	testLocalWriter(c, false, false)
 }
 
 func (s *localSuite) TestLocalWriterWithIngest(c *C) {
-	fmt.Println("TestLocalWriterWithIngest")
 	testLocalWriter(c, true, false)
 }
 
 func (s *localSuite) TestLocalWriterWithIngestUnsort(c *C) {
-	fmt.Println("TestLocalWriterWithIngestUnsort")
 	testLocalWriter(c, true, true)
 }

--- a/lightning/backend/tidb.go
+++ b/lightning/backend/tidb.go
@@ -188,13 +188,13 @@ func (enc *tidbEncoder) appendSQL(sb *strings.Builder, datum *types.Datum, col *
 		value := strconv.AppendFloat(buffer[:0], datum.GetFloat64(), 'g', -1, 64)
 		sb.Write(value)
 	case types.KindString:
-		if enc.mode.HasStrictMode() {
-			d, err := table.CastValue(enc.se, *datum, col.ToInfo(), false, false)
-			if err != nil {
-				return errors.Trace(err)
-			}
-			datum = &d
-		}
+		//if enc.mode.HasStrictMode() {
+		//	d, err := table.CastValue(enc.se, *datum, col.ToInfo(), false, false)
+		//	if err != nil {
+		//		return errors.Trace(err)
+		//	}
+		//	datum = &d
+		//}
 
 		enc.appendSQLBytes(sb, datum.GetBytes())
 	case types.KindBytes:

--- a/lightning/backend/tidb.go
+++ b/lightning/backend/tidb.go
@@ -188,6 +188,7 @@ func (enc *tidbEncoder) appendSQL(sb *strings.Builder, datum *types.Datum, col *
 		value := strconv.AppendFloat(buffer[:0], datum.GetFloat64(), 'g', -1, 64)
 		sb.Write(value)
 	case types.KindString:
+		// See: https://github.com/pingcap/tidb-lightning/issues/550
 		//if enc.mode.HasStrictMode() {
 		//	d, err := table.CastValue(enc.se, *datum, col.ToInfo(), false, false)
 		//	if err != nil {

--- a/lightning/backend/tidb_test.go
+++ b/lightning/backend/tidb_test.go
@@ -183,7 +183,8 @@ func (s *mysqlSuite) TestWriteRowsErrorOnDup(c *C) {
 	c.Assert(err, IsNil)
 }
 
-func (s *mysqlSuite) TestStrictMode(c *C) {
+// TODO: temporarily disable this test before we fix strict mode
+func (s *mysqlSuite) testStrictMode(c *C) {
 	ft := *types.NewFieldType(mysql.TypeVarchar)
 	ft.Charset = charset.CharsetUTF8MB4
 	col0 := &model.ColumnInfo{ID: 1, Name: model.NewCIStr("s0"), State: model.StatePublic, Offset: 0, FieldType: ft}


### PR DESCRIPTION

<!--
Thank you for contributing to TiDB-Lightning! Please read the [CONTRIBUTING](https://github.com/pingcap/tidb-lightning/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
#378 added string value check in tidb backend if the SQL mode is strict. But this causes #550  because tidb backend doesn't fetch the full table meta which causes CastValue panic. 

### What is changed and how it works?
Disable this feature before we come up with a correct solution.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

Side effects

Related changes
