### PR TITLE
metrics: use tidb_cluster label get variable values

### DIFF
--- a/metrics/grafana/lightning.json
+++ b/metrics/grafana/lightning.json
@@ -1554,7 +1554,7 @@
         "options": [
 
         ],
-        "query": "label_values(lightning_chunks, cluster)",
+        "query": "label_values(lightning_chunks, tidb_cluster)",
         "refresh": 2,
         "regex": "",
         "sort": 1,


### PR DESCRIPTION
Signed-off-by: zhengjiajin <zhengjiajin@pingcap.com>

<!--
Thank you for contributing to TiDB-Lightning! Please read the [CONTRIBUTING](https://github.com/pingcap/tidb-lightning/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
The latest version of tidb-operator will use the instance name as the cluster label. The previous expression uses the cluster label got the value of the tidb_cluster variable. It will cause Grafana can not to display the data.

### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - No code

Side effects

 - No effects

Related changes

 - https://github.com/pingcap/tidb/pull/22557