### PR TITLE
WIP: use system_time_zone to encode kv if tidb set it

### DIFF
--- a/lightning/backend/session.go
+++ b/lightning/backend/session.go
@@ -18,12 +18,14 @@ import (
 	"errors"
 	"fmt"
 	"strconv"
+	"time"
 
 	"github.com/pingcap/parser/model"
 	"github.com/pingcap/parser/mysql"
 	"github.com/pingcap/tidb/kv"
 	"github.com/pingcap/tidb/sessionctx"
 	"github.com/pingcap/tidb/sessionctx/variable"
+	"github.com/pingcap/tidb/util/timeutil"
 
 	"github.com/pingcap/tidb-lightning/lightning/common"
 )
@@ -194,12 +196,28 @@ func newSession(options *SessionOptions) *session {
 	vars.StmtCtx.OverflowAsWarning = !sqlMode.HasStrictMode()
 	vars.StmtCtx.AllowInvalidDate = sqlMode.HasAllowInvalidDatesMode()
 	vars.StmtCtx.IgnoreZeroInDate = !sqlMode.HasStrictMode() || sqlMode.HasAllowInvalidDatesMode()
+	tz := vars.Location()
 	if options.SysVars != nil {
+		var tidbTimeZone, tidbSystemTimeZone string
 		for k, v := range options.SysVars {
 			vars.SetSystemVar(k, v)
+			if k == "time_zone" {
+				tidbTimeZone = v
+			}
+			if k == "system_time_zone" {
+				tidbSystemTimeZone = v
+			}
+		}
+		// we get system zone from TiDB server, we can set it for lightning session.
+		if tidbTimeZone == "SYSTEM" && tidbSystemTimeZone != "" {
+			loc, err := timeutil.LoadLocation(tidbSystemTimeZone)
+			if err != nil {
+				loc = time.Local
+			}
+			tz = loc
 		}
 	}
-	vars.StmtCtx.TimeZone = vars.Location()
+	vars.StmtCtx.TimeZone = tz
 	vars.SetSystemVar("timestamp", strconv.FormatInt(options.Timestamp, 10))
 	vars.TxnCtx = nil
 

--- a/lightning/restore/tidb.go
+++ b/lightning/restore/tidb.go
@@ -50,6 +50,7 @@ var (
 		"max_allowed_packet":      "67108864",
 		"div_precision_increment": "4",
 		"time_zone":               "SYSTEM",
+		"system_time_zone":        "",
 		"lc_time_names":           "en_US",
 		"default_week_format":     "0",
 		"block_encryption_mode":   "aes-128-ecb",


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-Lightning! Please read the [CONTRIBUTING](https://github.com/pingcap/tidb-lightning/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Resolve #562 

### What is changed and how it works?
if tidb time_zone is "SYSTEM", try to use "system_time_zone" to set time_zone for lightning session.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation
 - Need to be included in the release note

### Release note

- Fix the issue that lightning didn't use tidb's time zone to encode timestamp data.