### PR TITLE
test: fix ssl key ca name

### DIFF
--- a/tests/_utils/run_services
+++ b/tests/_utils/run_services
@@ -34,7 +34,8 @@ DNS.1 = localhost
 IP.1 = 127.0.0.1
 EOF
     openssl ecparam -out "$TT/ca.key" -name prime256v1 -genkey
-    openssl req -new -batch -sha256 -subj '/CN=localhost' -key "$TT/ca.key" -out "$TT/ca.csr"
+    # CA's Common Name must not be the same as signed certificate.
+    openssl req -new -batch -sha256 -subj '/CN=lightning_tests' -key "$TT/ca.key" -out "$TT/ca.csr"
     openssl x509 -req -sha256 -days 2 -in "$TT/ca.csr" -signkey "$TT/ca.key" -out "$TT/ca.pem" 2> /dev/null
     for cluster in tidb pd tikv importer lightning tiflash curl; do
         openssl ecparam -out "$TT/$cluster.key" -name prime256v1 -genkey


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB-Lightning! Please read the [CONTRIBUTING](https://github.com/pingcap/tidb-lightning/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Use different CA common name to avoid tikv SSL verification failed.

### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Integration test

Side effects

Related changes
